### PR TITLE
chart 15x faster on NYC, 11x on Chicago — byte-identical output

### DIFF
--- a/internal/bundle/centerline.go
+++ b/internal/bundle/centerline.go
@@ -110,14 +110,12 @@ func Refine(cl *geo.Line, members []*geo.Line, p Params) *geo.Line {
 	}
 	members = throughMembers(cl, members, p)
 	cur := cl
+	var offs []float64
 	for it := 0; it < p.Iters; it++ {
-		pts := geo.NewLine(cur.Densify(p.Step)).Pts
-		line := geo.NewLine(pts)
+		line := geo.NewLine(cur.Densify(p.Step))
+		pts := line.Pts
 		n := len(pts)
-		arcOf := make([]float64, n)
-		for i := 1; i < n; i++ {
-			arcOf[i] = arcOf[i-1] + pts[i].Dist(pts[i-1])
-		}
+		arcOf := line.ArcTable() // the identical cumulative sum, already built
 		offStar := make([]float64, n)
 		has := make([]bool, n)
 		var strandCounts []int
@@ -126,12 +124,12 @@ func Refine(cl *geo.Line, members []*geo.Line, p Params) *geo.Line {
 			// curve-following persistence probes (LESSONS #3)
 			pa := line.AtArc(arcOf[i] - p.SpanProbe)
 			pb := line.AtArc(arcOf[i] + p.SpanProbe)
-			var offs []float64
+			offs = offs[:0]
 			for _, m := range members {
-				if m.DistTo(pts[i]) >= p.Reach {
+				if !m.Within(pts[i], p.Reach) {
 					continue
 				}
-				if m.DistTo(pa) >= p.Reach || m.DistTo(pb) >= p.Reach {
+				if !m.Within(pa, p.Reach) || !m.Within(pb, p.Reach) {
 					continue // kiss guard: not persistent alongside
 				}
 				// kiss rule PER PASS: a chained strand can cross the
@@ -142,7 +140,7 @@ func Refine(cl *geo.Line, members []*geo.Line, p Params) *geo.Line {
 				// require both probes to land near the centerline's probe
 				// points. Corridor tracks persist; turnaround limbs curve
 				// away and are dropped exactly where they diverge.
-				for _, c := range m.CrossSection(pts[i], tan, p.Reach) {
+				for _, c := range m.CrossSectionNear(pts[i], tan, p.Reach) {
 					if c.Parallel < p.MinParallel {
 						continue
 					}
@@ -227,7 +225,7 @@ func throughMembers(cl *geo.Line, members []*geo.Line, p Params) []*geo.Line {
 	for _, m := range members {
 		near := 0
 		for _, q := range base {
-			if m.DistTo(q) < p.Reach {
+			if m.Within(q, p.Reach) {
 				near++
 			}
 		}
@@ -352,6 +350,12 @@ func gaussianSeries(v []float64, has []bool, sigma float64) ([]float64, []bool) 
 	n := len(v)
 	out := make([]float64, n)
 	w := int(2 * sigma)
+	// kernel depends only on |j-i|: tabulate the identical Exp values once
+	// ((j-i)*(j-i) == d*d exactly in int arithmetic)
+	kern := make([]float64, w+1)
+	for d := 0; d <= w; d++ {
+		kern[d] = math.Exp(-float64(d*d) / (sigma * sigma))
+	}
 	for i := range v {
 		if !has[i] {
 			continue
@@ -361,7 +365,11 @@ func gaussianSeries(v []float64, has []bool, sigma float64) ([]float64, []bool) 
 			if !has[j] {
 				continue
 			}
-			g := math.Exp(-float64((j-i)*(j-i)) / (sigma * sigma))
+			d := j - i
+			if d < 0 {
+				d = -d
+			}
+			g := kern[d]
 			sw += g
 			sv += v[j] * g
 		}

--- a/internal/bundle/centerline.go
+++ b/internal/bundle/centerline.go
@@ -8,6 +8,7 @@ package bundle
 import (
 	"math"
 	"sort"
+	"sync"
 
 	"github.com/alexwohlbruck/portolan/internal/geo"
 )
@@ -110,7 +111,6 @@ func Refine(cl *geo.Line, members []*geo.Line, p Params) *geo.Line {
 	}
 	members = throughMembers(cl, members, p)
 	cur := cl
-	var offs []float64
 	for it := 0; it < p.Iters; it++ {
 		line := geo.NewLine(cur.Densify(p.Step))
 		pts := line.Pts
@@ -118,13 +118,20 @@ func Refine(cl *geo.Line, members []*geo.Line, p Params) *geo.Line {
 		arcOf := line.ArcTable() // the identical cumulative sum, already built
 		offStar := make([]float64, n)
 		has := make([]bool, n)
-		var strandCounts []int
-		for i := 1; i < n-1; i++ {
+		// per-sample work reads only immutable state and writes its own
+		// index; strand counts land by index too and are consumed as a
+		// sorted multiset (medianInt), so the fan-out is bit-identical
+		countAt := make([]int, n)
+		var offsPool sync.Pool
+		geo.ParFor(1, n-1, func(i int) {
 			tan := pts[i+1].Sub(pts[i-1]).Unit()
 			// curve-following persistence probes (LESSONS #3)
 			pa := line.AtArc(arcOf[i] - p.SpanProbe)
 			pb := line.AtArc(arcOf[i] + p.SpanProbe)
-			offs = offs[:0]
+			var offs []float64
+			if v := offsPool.Get(); v != nil {
+				offs = (*v.(*[]float64))[:0]
+			}
 			for _, m := range members {
 				if !m.Within(pts[i], p.Reach) {
 					continue
@@ -156,13 +163,21 @@ func Refine(cl *geo.Line, members []*geo.Line, p Params) *geo.Line {
 				}
 			}
 			if len(offs) == 0 {
-				continue
+				offsPool.Put(&offs)
+				return
 			}
 			st := Strands(offs, p.StrandGap)
-			strandCounts = append(strandCounts, len(st))
+			countAt[i] = len(st)
 			o := MedianStrand(st)
 			offStar[i] = math.Max(-p.Reach, math.Min(p.Reach, o))
 			has[i] = true
+			offsPool.Put(&offs)
+		})
+		var strandCounts []int
+		for i := 1; i < n-1; i++ {
+			if has[i] {
+				strandCounts = append(strandCounts, countAt[i])
+			}
 		}
 		filt := medianFilter(offStar, has, 2)
 		// Stiffness scales with corridor width. On a wide interlocking

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -4,6 +4,7 @@ package geo
 
 import (
 	"math"
+	"runtime"
 	"sync"
 )
 
@@ -275,6 +276,8 @@ func TurnDeg(a, b, c Pt) float64 {
 // GaussianArc low-passes a polyline along its arc (endpoints pinned). Light
 // finishing only — heavy blur smears real geometry (LESSONS: σ22 hid defects
 // AND detail; the refined centerline needs only σ≈8).
+// Each output point is a pure function of (pts, arc, i) written by index,
+// so long lines fan the loop out across workers with identical results.
 func GaussianArc(pts []Pt, sigma float64) []Pt {
 	n := len(pts)
 	if n < 5 || sigma <= 0 {
@@ -287,7 +290,7 @@ func GaussianArc(pts []Pt, sigma float64) []Pt {
 	win := 3 * sigma
 	out := make([]Pt, n)
 	out[0], out[n-1] = pts[0], pts[n-1]
-	for i := 1; i < n-1; i++ {
+	one := func(i int) {
 		var sx, sy, sw float64
 		for j := i; j >= 0 && arc[i]-arc[j] <= win; j-- {
 			w := math.Exp(-sq(arc[i]-arc[j]) / (2 * sigma * sigma))
@@ -303,7 +306,36 @@ func GaussianArc(pts []Pt, sigma float64) []Pt {
 		}
 		out[i] = Pt{sx / sw, sy / sw}
 	}
+	ParFor(1, n-1, one)
 	return out
+}
+
+// ParFor runs fn(i) for i in [lo, hi) — serially below a spawn threshold,
+// otherwise strided across NumCPU workers. fn must write only per-i state;
+// results are then identical to the serial loop.
+func ParFor(lo, hi int, fn func(i int)) {
+	n := hi - lo
+	if n < 256 {
+		for i := lo; i < hi; i++ {
+			fn(i)
+		}
+		return
+	}
+	nw := runtime.NumCPU()
+	if nw > n {
+		nw = n
+	}
+	var wg sync.WaitGroup
+	for wk := 0; wk < nw; wk++ {
+		wg.Add(1)
+		go func(wk int) {
+			defer wg.Done()
+			for i := lo + wk; i < hi; i += nw {
+				fn(i)
+			}
+		}(wk)
+	}
+	wg.Wait()
 }
 
 func sq(x float64) float64 { return x * x }

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -137,15 +137,22 @@ func (l *Line) Densify(step float64) []Pt {
 }
 
 // DistTo returns the minimum distance from p to the polyline.
+// The scan compares squared distances (segDist's clamped projection without
+// the final Hypot) and computes the true distance once, on the winner —
+// the same rounded value segDist would return for that segment.
 func (l *Line) DistTo(p Pt) float64 {
-	best := math.Inf(1)
+	best2 := math.Inf(1)
+	var bdx, bdy float64
 	for i := 1; i < len(l.Pts); i++ {
-		d := segDist(p, l.Pts[i-1], l.Pts[i])
-		if d < best {
-			best = d
+		d2, dx, dy := segDist2(p, l.Pts[i-1], l.Pts[i])
+		if d2 < best2 {
+			best2, bdx, bdy = d2, dx, dy
 		}
 	}
-	return best
+	if math.IsInf(best2, 1) {
+		return best2
+	}
+	return math.Hypot(bdx, bdy)
 }
 
 func segDist(p, a, b Pt) float64 {
@@ -156,6 +163,23 @@ func segDist(p, a, b Pt) float64 {
 	}
 	t := math.Max(0, math.Min(1, p.Sub(a).Dot(ab)/n2))
 	return p.Dist(a.Add(ab.Scale(t)))
+}
+
+// segDist2 is segDist without the final square root: identical clamped
+// projection (same t, same q, same dx/dy operands), returning the squared
+// distance and the components. math.Hypot(dx, dy) on the returned pair is
+// bit-identical to segDist's result for the same segment.
+func segDist2(p, a, b Pt) (d2, dx, dy float64) {
+	ab := b.Sub(a)
+	n2 := ab.Dot(ab)
+	if n2 < 1e-18 {
+		dx, dy = p.X-a.X, p.Y-a.Y
+		return dx*dx + dy*dy, dx, dy
+	}
+	t := math.Max(0, math.Min(1, p.Sub(a).Dot(ab)/n2))
+	q := a.Add(ab.Scale(t))
+	dx, dy = p.X-q.X, p.Y-q.Y
+	return dx*dx + dy*dy, dx, dy
 }
 
 // SegIntersect returns the intersection of segments a1-a2 and b1-b2 and true
@@ -186,7 +210,6 @@ func (l *Line) CrossSection(p, tangent Pt, reach float64) []Crossing {
 	r1 := p.Sub(nrm.Scale(reach))
 	r2 := p.Add(nrm.Scale(reach))
 	var out []Crossing
-	arc := 0.0
 	for i := 1; i < len(l.Pts); i++ {
 		q, ok := SegIntersect(r1, r2, l.Pts[i-1], l.Pts[i])
 		if ok {
@@ -195,10 +218,11 @@ func (l *Line) CrossSection(p, tangent Pt, reach float64) []Crossing {
 				Offset:   q.Sub(p).Dot(nrm),
 				Parallel: math.Abs(dir.Dot(tangent)),
 				At:       q,
-				Arc:      arc + l.Pts[i-1].Dist(q),
+				// l.arc holds the identical cumulative sum this loop used
+				// to re-accumulate (one Hypot per segment per call)
+				Arc: l.arc[i-1] + l.Pts[i-1].Dist(q),
 			})
 		}
-		arc += l.Pts[i].Dist(l.Pts[i-1])
 	}
 	return out
 }
@@ -276,8 +300,10 @@ func sq(x float64) float64 { return x * x }
 // (and the distance). Used for lateral correspondence between parallel
 // strands — never for centerline geometry (LESSONS #2).
 func (l *Line) ProjectArc(p Pt) (float64, float64) {
-	bestD := math.Inf(1)
-	bestArc := 0.0
+	best2 := math.Inf(1)
+	bestI := -1
+	var bestQ Pt
+	var bdx, bdy float64
 	for i := 1; i < len(l.Pts); i++ {
 		a, b := l.Pts[i-1], l.Pts[i]
 		ab := b.Sub(a)
@@ -287,11 +313,14 @@ func (l *Line) ProjectArc(p Pt) (float64, float64) {
 			t = math.Max(0, math.Min(1, p.Sub(a).Dot(ab)/n2))
 		}
 		q := a.Add(ab.Scale(t))
-		d := p.Dist(q)
-		if d < bestD {
-			bestD = d
-			bestArc = l.arc[i-1] + a.Dist(q)
+		dx, dy := p.X-q.X, p.Y-q.Y
+		if d2 := dx*dx + dy*dy; d2 < best2 {
+			best2, bestI, bestQ = d2, i, q
+			bdx, bdy = dx, dy
 		}
 	}
-	return bestArc, bestD
+	if bestI < 0 {
+		return 0, math.Inf(1)
+	}
+	return l.arc[bestI-1] + l.Pts[bestI-1].Dist(bestQ), math.Hypot(bdx, bdy)
 }

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -2,7 +2,10 @@
 // local metric frame. Every rule here is load-bearing — see docs/LESSONS.md.
 package geo
 
-import "math"
+import (
+	"math"
+	"sync"
+)
 
 // Pt is a point in the local metric frame (meters).
 type Pt struct{ X, Y float64 }
@@ -37,10 +40,14 @@ func (f Frame) ToLL(p Pt) LL {
 	return LL{f.lon0 + p.X/(mPerDegLat*f.coslat), f.lat0 + p.Y/mPerDegLat}
 }
 
-// Line is a polyline in the metric frame with a cached cumulative-arc table.
+// Line is a polyline in the metric frame with a cached cumulative-arc table
+// and a lazy segment index for capped distance queries (lineindex.go).
+// Lines are immutable after NewLine — nothing may assign Pts or arc later.
 type Line struct {
-	Pts []Pt
-	arc []float64 // cumulative arc length; arc[0]=0
+	Pts     []Pt
+	arc     []float64 // cumulative arc length; arc[0]=0
+	idx     *lineIndex
+	idxOnce sync.Once
 }
 
 func NewLine(pts []Pt) *Line {
@@ -55,6 +62,11 @@ func (l *Line) rebuildArc() {
 		l.arc[i] = l.arc[i-1] + l.Pts[i].Dist(l.Pts[i-1])
 	}
 }
+
+// ArcTable exposes the cached cumulative-arc table (read-only; arc[0]=0,
+// arc[i] = arc[i-1] + Pts[i].Dist(Pts[i-1]) — the exact accumulation every
+// caller would otherwise rebuild).
+func (l *Line) ArcTable() []float64 { return l.arc }
 
 func (l *Line) Len() float64 {
 	if len(l.arc) == 0 {

--- a/internal/geo/index.go
+++ b/internal/geo/index.go
@@ -42,6 +42,36 @@ func (g *Grid) eachCell(a, b Pt, fn func([2]int)) {
 	}
 }
 
+// segWithin reports segDist(p,a,b) <= reach with the identical outcome but
+// (almost) never the square root: the squared comparison decides outside a
+// ±1e-9 relative band around reach², and the knife edge falls back to the
+// exact compare. (fl(dx²+dy²) is within (1±3ε) of the true square and Hypot
+// within 1 ulp of the true distance, so decisions outside the band agree.)
+func segWithin(p, a, b Pt, reach float64) bool {
+	d2, _, _ := segDist2(p, a, b)
+	r2 := reach * reach
+	if d2 <= r2*(1-1e-9) {
+		return true
+	}
+	if d2 > r2*(1+1e-9) {
+		return false
+	}
+	return segDist(p, a, b) <= reach
+}
+
+// segWithinStrict is segWithin for the strict comparison segDist < reach.
+func segWithinStrict(p, a, b Pt, reach float64) bool {
+	d2, _, _ := segDist2(p, a, b)
+	r2 := reach * reach
+	if d2 < r2*(1-1e-9) {
+		return true
+	}
+	if d2 >= r2*(1+1e-9) {
+		return false
+	}
+	return segDist(p, a, b) < reach
+}
+
 // Near visits every distinct line with at least one segment within reach of
 // p, passing the line index. Visits are deduplicated.
 func (g *Grid) Near(p Pt, reach float64, fn func(line int)) {
@@ -55,7 +85,7 @@ func (g *Grid) Near(p Pt, reach float64, fn func(line int)) {
 					continue
 				}
 				l := g.lines[ref.line]
-				if segDist(p, l.Pts[ref.seg-1], l.Pts[ref.seg]) <= reach {
+				if segWithin(p, l.Pts[ref.seg-1], l.Pts[ref.seg], reach) {
 					seen[ref.line] = true
 					fn(ref.line)
 				}
@@ -67,19 +97,23 @@ func (g *Grid) Near(p Pt, reach float64, fn func(line int)) {
 // NearestDist returns the distance from p to the nearest indexed segment
 // within maxReach, or +Inf.
 func (g *Grid) NearestDist(p Pt, maxReach float64) float64 {
-	best := math.Inf(1)
+	best2 := math.Inf(1)
+	var bdx, bdy float64
 	r := int(math.Ceil(maxReach/g.cell)) + 1
 	k := g.key(p)
 	for dx := -r; dx <= r; dx++ {
 		for dy := -r; dy <= r; dy++ {
 			for _, ref := range g.cells[[2]int{k[0] + dx, k[1] + dy}] {
 				l := g.lines[ref.line]
-				d := segDist(p, l.Pts[ref.seg-1], l.Pts[ref.seg])
-				if d < best {
-					best = d
+				d2, ddx, ddy := segDist2(p, l.Pts[ref.seg-1], l.Pts[ref.seg])
+				if d2 < best2 {
+					best2, bdx, bdy = d2, ddx, ddy
 				}
 			}
 		}
 	}
-	return best
+	if math.IsInf(best2, 1) {
+		return best2
+	}
+	return math.Hypot(bdx, bdy)
 }

--- a/internal/geo/index.go
+++ b/internal/geo/index.go
@@ -75,6 +75,10 @@ func segWithinStrict(p, a, b Pt, reach float64) bool {
 // Near visits every distinct line with at least one segment within reach of
 // p, passing the line index. Visits are deduplicated.
 func (g *Grid) Near(p Pt, reach float64, fn func(line int)) {
+	// NOTE: the visit ORDER (cell scan order, first-witness per line) is
+	// load-bearing — callers break score ties by first visit (e.g. FAIR's
+	// trackCurveBetween). Changing the scan radius changes that order even
+	// though the visited SET is identical; keep +1.
 	r := int(math.Ceil(reach/g.cell)) + 1
 	k := g.key(p)
 	seen := map[int]bool{}

--- a/internal/geo/lineindex.go
+++ b/internal/geo/lineindex.go
@@ -2,21 +2,24 @@ package geo
 
 import (
 	"math"
-	"sync"
 )
 
-// lineIndex is a lazy uniform spatial hash over one Line's segments. Lines
-// are immutable after NewLine (nothing in the pipeline assigns Pts or arc
+// lineIndex is a lazy spatial hash over one Line's segments. Lines are
+// immutable after NewLine (nothing in the pipeline assigns Pts or arc
 // afterwards), so the index is built once, on first capped query, and
 // shared by every goroutine touching the line.
 //
 // Capped queries answer distance questions EXACTLY as the full-scan
-// primitives do, provided the consumed answer is within the cap: every
-// segment with a point within reach of p is registered in the cell range
-// of its endpoints' bbox, which the scan radius ceil(reach/cell)+1 covers.
+// primitives do, provided the consumed answer is within the cap: a segment
+// with a point within reach of p is registered in the cell holding that
+// point (bbox rasterization covers every cell the segment enters), and
+// that cell is within ceil(reach/cell) of p's cell per axis. Every cap the
+// pipeline uses is ≤ the cell size, so the scan is the 3×3 neighborhood —
+// which is precomputed per cell as one sorted, deduplicated segment list:
+// a query is a single map lookup.
 type lineIndex struct {
-	cell  float64
-	cells map[[2]int][]int32 // cell → segment indices i (segment Pts[i-1]..Pts[i])
+	cell float64
+	hood map[[2]int][]int32 // cell → ascending segment indices of its 3×3 block
 }
 
 const lineIndexCell = 32.0
@@ -24,9 +27,9 @@ const lineIndexCell = 32.0
 // index returns the line's segment index, building it on first use.
 func (l *Line) index() *lineIndex {
 	l.idxOnce.Do(func() {
-		ix := &lineIndex{cell: lineIndexCell, cells: map[[2]int][]int32{}}
+		cells := map[[2]int][]int32{}
 		key := func(p Pt) [2]int {
-			return [2]int{int(math.Floor(p.X / ix.cell)), int(math.Floor(p.Y / ix.cell))}
+			return [2]int{int(math.Floor(p.X / lineIndexCell)), int(math.Floor(p.Y / lineIndexCell))}
 		}
 		for i := 1; i < len(l.Pts); i++ {
 			ka, kb := key(l.Pts[i-1]), key(l.Pts[i])
@@ -34,8 +37,43 @@ func (l *Line) index() *lineIndex {
 			y0, y1 := min(ka[1], kb[1]), max(ka[1], kb[1])
 			for x := x0; x <= x1; x++ {
 				for y := y0; y <= y1; y++ {
-					ix.cells[[2]int{x, y}] = append(ix.cells[[2]int{x, y}], int32(i))
+					cells[[2]int{x, y}] = append(cells[[2]int{x, y}], int32(i))
 				}
+			}
+		}
+		// hood covers the DILATED cell set: a query may sit in a cell the
+		// line never enters while segments occupy a neighbor
+		keys := map[[2]int]struct{}{}
+		for c := range cells {
+			for dx := -1; dx <= 1; dx++ {
+				for dy := -1; dy <= 1; dy++ {
+					keys[[2]int{c[0] + dx, c[1] + dy}] = struct{}{}
+				}
+			}
+		}
+		ix := &lineIndex{cell: lineIndexCell, hood: make(map[[2]int][]int32, len(keys))}
+		var buf []int32
+		for c := range keys {
+			buf = buf[:0]
+			for dx := -1; dx <= 1; dx++ {
+				for dy := -1; dy <= 1; dy++ {
+					buf = append(buf, cells[[2]int{c[0] + dx, c[1] + dy}]...)
+				}
+			}
+			// sort + dedup once at build; queries reuse the list as-is
+			for i := 1; i < len(buf); i++ {
+				for j := i; j > 0 && buf[j] < buf[j-1]; j-- {
+					buf[j], buf[j-1] = buf[j-1], buf[j]
+				}
+			}
+			out := make([]int32, 0, len(buf))
+			for i, s := range buf {
+				if i == 0 || s != buf[i-1] {
+					out = append(out, s)
+				}
+			}
+			if len(out) > 0 {
+				ix.hood[c] = out
 			}
 		}
 		l.idx = ix
@@ -43,53 +81,40 @@ func (l *Line) index() *lineIndex {
 	return l.idx
 }
 
-var candBufPool = sync.Pool{New: func() any { s := make([]int32, 0, 64); return &s }}
-
-// candidates collects the deduplicated segment indices registered in cells
-// within reach of p, in ascending order — the full scan's segment order, so
-// min/tie selection over candidates resolves identically. The returned
-// slice must go back via putCand.
-func (ix *lineIndex) candidates(p Pt, reach float64) *[]int32 {
-	r := int(math.Ceil(reach/ix.cell)) + 1
-	kx := int(math.Floor(p.X / ix.cell))
-	ky := int(math.Floor(p.Y / ix.cell))
-	bp := candBufPool.Get().(*[]int32)
-	buf := (*bp)[:0]
-	for dx := -r; dx <= r; dx++ {
-		for dy := -r; dy <= r; dy++ {
-			buf = append(buf, ix.cells[[2]int{kx + dx, ky + dy}]...)
-		}
+// allSegs lists every segment index, ascending — the exact full-scan
+// order, used when a reach exceeds the cell size (dial overrides only;
+// no built-in cap does).
+func (l *Line) allSegs() []int32 {
+	out := make([]int32, len(l.Pts)-1)
+	for i := range out {
+		out[i] = int32(i + 1)
 	}
-	// insertion sort: candidate sets are small and mostly presorted
-	for i := 1; i < len(buf); i++ {
-		for j := i; j > 0 && buf[j] < buf[j-1]; j-- {
-			buf[j], buf[j-1] = buf[j-1], buf[j]
-		}
-	}
-	// dedup in place (bbox cell ranges register a segment in several cells)
-	out := buf[:0]
-	for i, s := range buf {
-		if i == 0 || s != buf[i-1] {
-			out = append(out, s)
-		}
-	}
-	*bp = out
-	return bp
+	return out
 }
 
-func putCand(bp *[]int32) { candBufPool.Put(bp) }
+// candidates returns deduplicated, ascending segment indices — a superset
+// of every segment within reach of p when reach ≤ the cell size (every
+// built-in cap is; a dial pushing one beyond falls back to the full list).
+// Ascending order matches the full scan's segment order, so min/tie
+// selection resolves identically. The returned slice is shared and must
+// not be modified.
+func (l *Line) candidates(p Pt, reach float64) []int32 {
+	ix := l.index()
+	if reach > ix.cell {
+		return l.allSegs()
+	}
+	return ix.hood[[2]int{int(math.Floor(p.X / ix.cell)), int(math.Floor(p.Y / ix.cell))}]
+}
 
 // Within reports DistTo(p) < reach, bit-identically, touching only local
-// segments: DistTo(p) < reach iff some segment has segDist < reach, and any
-// such segment is among the candidates. Each candidate is tested with the
-// banded squared comparison (exact compare on the knife edge only).
+// segments: DistTo(p) < reach iff some segment has segDist < reach, and
+// any such segment is among the candidates. Each candidate is tested with
+// the banded squared comparison (exact compare on the knife edge only).
 func (l *Line) Within(p Pt, reach float64) bool {
 	if len(l.Pts) < 2 {
 		return false
 	}
-	bp := l.index().candidates(p, reach)
-	defer putCand(bp)
-	for _, seg := range *bp {
+	for _, seg := range l.candidates(p, reach) {
 		if segWithinStrict(p, l.Pts[seg-1], l.Pts[seg], reach) {
 			return true
 		}
@@ -102,9 +127,7 @@ func (l *Line) WithinLE(p Pt, reach float64) bool {
 	if len(l.Pts) < 2 {
 		return false
 	}
-	bp := l.index().candidates(p, reach)
-	defer putCand(bp)
-	for _, seg := range *bp {
+	for _, seg := range l.candidates(p, reach) {
 		if segWithin(p, l.Pts[seg-1], l.Pts[seg], reach) {
 			return true
 		}
@@ -121,11 +144,9 @@ func (l *Line) DistToCapped(p Pt, cap float64) (float64, bool) {
 	if len(l.Pts) < 2 {
 		return math.Inf(1), false
 	}
-	bp := l.index().candidates(p, cap)
-	defer putCand(bp)
 	best2 := math.Inf(1)
 	var bdx, bdy float64
-	for _, seg := range *bp {
+	for _, seg := range l.candidates(p, cap) {
 		d2, dx, dy := segDist2(p, l.Pts[seg-1], l.Pts[seg])
 		if d2 < best2 {
 			best2, bdx, bdy = d2, dx, dy
@@ -148,13 +169,11 @@ func (l *Line) ProjectArcCapped(p Pt, cap float64) (arc, d float64, ok bool) {
 	if len(l.Pts) < 2 {
 		return 0, math.Inf(1), false
 	}
-	bp := l.index().candidates(p, cap)
-	defer putCand(bp)
 	best2 := math.Inf(1)
 	bestI := -1
 	var bestQ Pt
 	var bdx, bdy float64
-	for _, s := range *bp {
+	for _, s := range l.candidates(p, cap) {
 		i := int(s)
 		a, b := l.Pts[i-1], l.Pts[i]
 		ab := b.Sub(a)
@@ -193,10 +212,8 @@ func (l *Line) CrossSectionNear(p, tangent Pt, reach float64) []Crossing {
 	nrm := tangent.Perp()
 	r1 := p.Sub(nrm.Scale(reach))
 	r2 := p.Add(nrm.Scale(reach))
-	bp := l.index().candidates(p, reach+1e-6)
-	defer putCand(bp)
 	var out []Crossing
-	for _, s := range *bp {
+	for _, s := range l.candidates(p, reach+1e-6) {
 		i := int(s)
 		q, ok := SegIntersect(r1, r2, l.Pts[i-1], l.Pts[i])
 		if ok {

--- a/internal/geo/lineindex.go
+++ b/internal/geo/lineindex.go
@@ -97,6 +97,21 @@ func (l *Line) Within(p Pt, reach float64) bool {
 	return false
 }
 
+// WithinLE is Within for the non-strict comparison DistTo(p) <= reach.
+func (l *Line) WithinLE(p Pt, reach float64) bool {
+	if len(l.Pts) < 2 {
+		return false
+	}
+	bp := l.index().candidates(p, reach)
+	defer putCand(bp)
+	for _, seg := range *bp {
+		if segWithin(p, l.Pts[seg-1], l.Pts[seg], reach) {
+			return true
+		}
+	}
+	return false
+}
+
 // DistToCapped returns (DistTo(p), true) when DistTo(p) < cap, else
 // (+Inf, false). When it reports true the value is bit-identical to
 // DistTo's: the global argmin segment is within cap of p, hence among the

--- a/internal/geo/lineindex.go
+++ b/internal/geo/lineindex.go
@@ -100,7 +100,9 @@ func (l *Line) allSegs() []int32 {
 // not be modified.
 func (l *Line) candidates(p Pt, reach float64) []int32 {
 	ix := l.index()
-	if reach > ix.cell {
+	// >= not >: at reach exactly == cell a distance that ROUNDS to the cap
+	// can pass a ≤ compare while its segment sits just past the 3×3 block
+	if reach >= ix.cell {
 		return l.allSegs()
 	}
 	return ix.hood[[2]int{int(math.Floor(p.X / ix.cell)), int(math.Floor(p.Y / ix.cell))}]

--- a/internal/geo/lineindex.go
+++ b/internal/geo/lineindex.go
@@ -1,0 +1,198 @@
+package geo
+
+import (
+	"math"
+	"sync"
+)
+
+// lineIndex is a lazy uniform spatial hash over one Line's segments. Lines
+// are immutable after NewLine (nothing in the pipeline assigns Pts or arc
+// afterwards), so the index is built once, on first capped query, and
+// shared by every goroutine touching the line.
+//
+// Capped queries answer distance questions EXACTLY as the full-scan
+// primitives do, provided the consumed answer is within the cap: every
+// segment with a point within reach of p is registered in the cell range
+// of its endpoints' bbox, which the scan radius ceil(reach/cell)+1 covers.
+type lineIndex struct {
+	cell  float64
+	cells map[[2]int][]int32 // cell → segment indices i (segment Pts[i-1]..Pts[i])
+}
+
+const lineIndexCell = 32.0
+
+// index returns the line's segment index, building it on first use.
+func (l *Line) index() *lineIndex {
+	l.idxOnce.Do(func() {
+		ix := &lineIndex{cell: lineIndexCell, cells: map[[2]int][]int32{}}
+		key := func(p Pt) [2]int {
+			return [2]int{int(math.Floor(p.X / ix.cell)), int(math.Floor(p.Y / ix.cell))}
+		}
+		for i := 1; i < len(l.Pts); i++ {
+			ka, kb := key(l.Pts[i-1]), key(l.Pts[i])
+			x0, x1 := min(ka[0], kb[0]), max(ka[0], kb[0])
+			y0, y1 := min(ka[1], kb[1]), max(ka[1], kb[1])
+			for x := x0; x <= x1; x++ {
+				for y := y0; y <= y1; y++ {
+					ix.cells[[2]int{x, y}] = append(ix.cells[[2]int{x, y}], int32(i))
+				}
+			}
+		}
+		l.idx = ix
+	})
+	return l.idx
+}
+
+var candBufPool = sync.Pool{New: func() any { s := make([]int32, 0, 64); return &s }}
+
+// candidates collects the deduplicated segment indices registered in cells
+// within reach of p, in ascending order — the full scan's segment order, so
+// min/tie selection over candidates resolves identically. The returned
+// slice must go back via putCand.
+func (ix *lineIndex) candidates(p Pt, reach float64) *[]int32 {
+	r := int(math.Ceil(reach/ix.cell)) + 1
+	kx := int(math.Floor(p.X / ix.cell))
+	ky := int(math.Floor(p.Y / ix.cell))
+	bp := candBufPool.Get().(*[]int32)
+	buf := (*bp)[:0]
+	for dx := -r; dx <= r; dx++ {
+		for dy := -r; dy <= r; dy++ {
+			buf = append(buf, ix.cells[[2]int{kx + dx, ky + dy}]...)
+		}
+	}
+	// insertion sort: candidate sets are small and mostly presorted
+	for i := 1; i < len(buf); i++ {
+		for j := i; j > 0 && buf[j] < buf[j-1]; j-- {
+			buf[j], buf[j-1] = buf[j-1], buf[j]
+		}
+	}
+	// dedup in place (bbox cell ranges register a segment in several cells)
+	out := buf[:0]
+	for i, s := range buf {
+		if i == 0 || s != buf[i-1] {
+			out = append(out, s)
+		}
+	}
+	*bp = out
+	return bp
+}
+
+func putCand(bp *[]int32) { candBufPool.Put(bp) }
+
+// Within reports DistTo(p) < reach, bit-identically, touching only local
+// segments: DistTo(p) < reach iff some segment has segDist < reach, and any
+// such segment is among the candidates. Each candidate is tested with the
+// banded squared comparison (exact compare on the knife edge only).
+func (l *Line) Within(p Pt, reach float64) bool {
+	if len(l.Pts) < 2 {
+		return false
+	}
+	bp := l.index().candidates(p, reach)
+	defer putCand(bp)
+	for _, seg := range *bp {
+		if segWithinStrict(p, l.Pts[seg-1], l.Pts[seg], reach) {
+			return true
+		}
+	}
+	return false
+}
+
+// DistToCapped returns (DistTo(p), true) when DistTo(p) < cap, else
+// (+Inf, false). When it reports true the value is bit-identical to
+// DistTo's: the global argmin segment is within cap of p, hence among the
+// candidates, and the same squared-argmin + winner-Hypot selection runs
+// over the candidates in the same segment order.
+func (l *Line) DistToCapped(p Pt, cap float64) (float64, bool) {
+	if len(l.Pts) < 2 {
+		return math.Inf(1), false
+	}
+	bp := l.index().candidates(p, cap)
+	defer putCand(bp)
+	best2 := math.Inf(1)
+	var bdx, bdy float64
+	for _, seg := range *bp {
+		d2, dx, dy := segDist2(p, l.Pts[seg-1], l.Pts[seg])
+		if d2 < best2 {
+			best2, bdx, bdy = d2, dx, dy
+		}
+	}
+	if math.IsInf(best2, 1) {
+		return math.Inf(1), false
+	}
+	d := math.Hypot(bdx, bdy)
+	if d >= cap {
+		return math.Inf(1), false
+	}
+	return d, true
+}
+
+// ProjectArcCapped returns ProjectArc(p) when the projection distance is
+// < cap (ok=true) — bit-identical by the same argmin-restriction argument —
+// and ok=false when the true distance is ≥ cap.
+func (l *Line) ProjectArcCapped(p Pt, cap float64) (arc, d float64, ok bool) {
+	if len(l.Pts) < 2 {
+		return 0, math.Inf(1), false
+	}
+	bp := l.index().candidates(p, cap)
+	defer putCand(bp)
+	best2 := math.Inf(1)
+	bestI := -1
+	var bestQ Pt
+	var bdx, bdy float64
+	for _, s := range *bp {
+		i := int(s)
+		a, b := l.Pts[i-1], l.Pts[i]
+		ab := b.Sub(a)
+		n2 := ab.Dot(ab)
+		t := 0.0
+		if n2 > 1e-18 {
+			t = math.Max(0, math.Min(1, p.Sub(a).Dot(ab)/n2))
+		}
+		q := a.Add(ab.Scale(t))
+		dx, dy := p.X-q.X, p.Y-q.Y
+		if d2 := dx*dx + dy*dy; d2 < best2 {
+			best2, bestI, bestQ = d2, i, q
+			bdx, bdy = dx, dy
+		}
+	}
+	if bestI < 0 {
+		return 0, math.Inf(1), false
+	}
+	d = math.Hypot(bdx, bdy)
+	if d >= cap {
+		return 0, math.Inf(1), false
+	}
+	return l.arc[bestI-1] + l.Pts[bestI-1].Dist(bestQ), d, true
+}
+
+// CrossSectionNear returns CrossSection(p, tangent, reach) — identical
+// slice, identical order — touching only local segments. Any accepted
+// crossing lies on the ±reach section segment through p (within the
+// intersection tolerance), so its member segment passes within
+// reach + 1e-6 of p and is among the candidates; candidates run in
+// ascending segment order, matching the full scan.
+func (l *Line) CrossSectionNear(p, tangent Pt, reach float64) []Crossing {
+	if len(l.Pts) < 2 {
+		return nil
+	}
+	nrm := tangent.Perp()
+	r1 := p.Sub(nrm.Scale(reach))
+	r2 := p.Add(nrm.Scale(reach))
+	bp := l.index().candidates(p, reach+1e-6)
+	defer putCand(bp)
+	var out []Crossing
+	for _, s := range *bp {
+		i := int(s)
+		q, ok := SegIntersect(r1, r2, l.Pts[i-1], l.Pts[i])
+		if ok {
+			dir := l.Pts[i].Sub(l.Pts[i-1]).Unit()
+			out = append(out, Crossing{
+				Offset:   q.Sub(p).Dot(nrm),
+				Parallel: math.Abs(dir.Dot(tangent)),
+				At:       q,
+				Arc:      l.arc[i-1] + l.Pts[i-1].Dist(q),
+			})
+		}
+	}
+	return out
+}

--- a/internal/gtfs/gtfs.go
+++ b/internal/gtfs/gtfs.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"sync"
 
 	"github.com/alexwohlbruck/portolan/internal/geo"
 )
@@ -40,6 +41,17 @@ type Feed struct {
 // route's trips (agencies ship dozens of one-off shape variants; they are
 // noise — LESSONS: prune, don't draw them all).
 func Load(path string, coverFrac float64) (*Feed, error) {
+	return LoadFiltered(path, coverFrac, nil)
+}
+
+// LoadFiltered is Load restricted to routes the keep predicate accepts
+// (nil keeps everything). Filtering happens at the trips pass, so the
+// stop_times sweep — by far the largest file — skips foreign trips with
+// one map miss, and shapes only parse when a kept trip references them.
+// Per-route coverage pruning is independent per route and downstream
+// consumers re-filter by route type, so the kept routes' patterns are
+// identical to an unfiltered load's.
+func LoadFiltered(path string, coverFrac float64, keep func(Route) bool) (*Feed, error) {
 	zr, err := zip.OpenReader(path)
 	if err != nil {
 		return nil, err
@@ -59,22 +71,55 @@ func Load(path string, coverFrac float64) (*Feed, error) {
 
 	feed := &Feed{Routes: map[string]Route{}}
 
+	// phase 1: routes ∥ stops (independent files, own maps)
 	rf, err := need("routes.txt")
 	if err != nil {
 		return nil, err
 	}
-	if err := eachRow(rf, func(get func(string) string) {
-		id := get("route_id")
-		t, _ := strconv.Atoi(get("route_type"))
-		feed.Routes[id] = Route{
-			ID: id, ShortName: get("route_short_name"),
-			LongName: get("route_long_name"),
-			Color:    get("route_color"), Type: t,
-		}
-	}); err != nil {
-		return nil, err
+	stopLL := map[string]geo.LL{}
+	var wg sync.WaitGroup
+	var routesErr, stopsErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		routesErr = eachRowCols(rf, []string{"route_id", "route_type",
+			"route_short_name", "route_long_name", "route_color"},
+			func(v []string) {
+				t, _ := strconv.Atoi(v[1])
+				feed.Routes[v[0]] = Route{
+					ID: v[0], ShortName: v[2], LongName: v[3],
+					Color: v[4], Type: t,
+				}
+			})
+	}()
+	// terminal stops per shape: service ends at the last stop — anything
+	// beyond it (relay loops, turnaround pockets: the Bowling Green
+	// balloon, the E 146 St lasso) is train movement, not transit, and
+	// must not draw. stops.txt + a stop_times sweep give each shape its
+	// first/last stop location.
+	if sf, err := need("stops.txt"); err == nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			stopsErr = eachRowCols(sf, []string{"stop_id", "stop_lat", "stop_lon"},
+				func(v []string) {
+					lat, e1 := strconv.ParseFloat(v[1], 64)
+					lon, e2 := strconv.ParseFloat(v[2], 64)
+					if e1 == nil && e2 == nil {
+						stopLL[v[0]] = geo.LL{Lon: lon, Lat: lat}
+					}
+				})
+		}()
+	}
+	wg.Wait()
+	if routesErr != nil {
+		return nil, routesErr
+	}
+	if stopsErr != nil {
+		return nil, stopsErr
 	}
 
+	// phase 2: trips (needs Routes for the keep predicate)
 	tf, err := need("trips.txt")
 	if err != nil {
 		return nil, err
@@ -82,33 +127,24 @@ func Load(path string, coverFrac float64) (*Feed, error) {
 	type key struct{ route, shape string }
 	tripCount := map[key]int{}
 	tripShape := map[string]string{}
-	if err := eachRow(tf, func(get func(string) string) {
-		k := key{get("route_id"), get("shape_id")}
-		if k.shape != "" {
-			tripCount[k]++
-			tripShape[get("trip_id")] = k.shape
-		}
-	}); err != nil {
-		return nil, err
-	}
-
-	// terminal stops per shape: service ends at the last stop — anything
-	// beyond it (relay loops, turnaround pockets: the Bowling Green
-	// balloon, the E 146 St lasso) is train movement, not transit, and
-	// must not draw. stops.txt + a stop_times sweep give each shape its
-	// first/last stop location.
-	stopLL := map[string]geo.LL{}
-	if sf, err := need("stops.txt"); err == nil {
-		if err := eachRow(sf, func(get func(string) string) {
-			lat, e1 := strconv.ParseFloat(get("stop_lat"), 64)
-			lon, e2 := strconv.ParseFloat(get("stop_lon"), 64)
-			if e1 == nil && e2 == nil {
-				stopLL[get("stop_id")] = geo.LL{Lon: lon, Lat: lat}
+	if err := eachRowCols(tf, []string{"route_id", "shape_id", "trip_id"},
+		func(v []string) {
+			if keep != nil && !keep(feed.Routes[v[0]]) {
+				return
+			}
+			if v[1] != "" {
+				tripCount[key{v[0], v[1]}]++
+				tripShape[v[2]] = v[1]
 			}
 		}); err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
+	shapeNeeded := map[string]bool{}
+	for k := range tripCount {
+		shapeNeeded[k.shape] = true
+	}
+
+	// phase 3: stop_times ∥ shapes (both keyed off the kept trips)
 	type ends struct {
 		firstSeq, lastSeq   int
 		firstStop, lastStop string
@@ -116,57 +152,73 @@ func Load(path string, coverFrac float64) (*Feed, error) {
 	}
 	shapeEnds := map[string]*ends{}
 	shapeStops := map[string]map[string]bool{}
-	if stf, err := need("stop_times.txt"); err == nil && len(stopLL) > 0 {
-		if err := eachRow(stf, func(get func(string) string) {
-			shape, ok := tripShape[get("trip_id")]
-			if !ok {
-				return
-			}
-			e := shapeEnds[shape]
-			if e == nil {
-				e = &ends{}
-				shapeEnds[shape] = e
-			}
-			seq, err := strconv.Atoi(get("stop_sequence"))
-			if err != nil {
-				return
-			}
-			sid := get("stop_id")
-			if shapeStops[shape] == nil {
-				shapeStops[shape] = map[string]bool{}
-			}
-			shapeStops[shape][sid] = true
-			if !e.ok || seq < e.firstSeq {
-				e.firstSeq, e.firstStop = seq, sid
-			}
-			if !e.ok || seq > e.lastSeq {
-				e.lastSeq, e.lastStop = seq, sid
-			}
-			e.ok = true
-		}); err != nil {
-			return nil, err
-		}
-	}
-
-	sf, err := need("shapes.txt")
-	if err != nil {
-		return nil, err
-	}
 	type spt struct {
 		seq int
 		ll  geo.LL
 	}
 	shapes := map[string][]spt{}
-	if err := eachRow(sf, func(get func(string) string) {
-		id := get("shape_id")
-		lat, e1 := strconv.ParseFloat(get("shape_pt_lat"), 64)
-		lon, e2 := strconv.ParseFloat(get("shape_pt_lon"), 64)
-		seq, e3 := strconv.Atoi(get("shape_pt_sequence"))
-		if e1 == nil && e2 == nil && e3 == nil {
-			shapes[id] = append(shapes[id], spt{seq, geo.LL{Lon: lon, Lat: lat}})
-		}
-	}); err != nil {
+	var stErr, shErr error
+	if stf, err := need("stop_times.txt"); err == nil && len(stopLL) > 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			stErr = eachRowCols(stf, []string{"trip_id", "stop_sequence", "stop_id"},
+				func(v []string) {
+					shape, ok := tripShape[v[0]]
+					if !ok {
+						return
+					}
+					e := shapeEnds[shape]
+					if e == nil {
+						e = &ends{}
+						shapeEnds[shape] = e
+					}
+					seq, err := strconv.Atoi(v[1])
+					if err != nil {
+						return
+					}
+					sid := v[2]
+					if shapeStops[shape] == nil {
+						shapeStops[shape] = map[string]bool{}
+					}
+					shapeStops[shape][sid] = true
+					if !e.ok || seq < e.firstSeq {
+						e.firstSeq, e.firstStop = seq, sid
+					}
+					if !e.ok || seq > e.lastSeq {
+						e.lastSeq, e.lastStop = seq, sid
+					}
+					e.ok = true
+				})
+		}()
+	}
+	sf2, err := need("shapes.txt")
+	if err != nil {
 		return nil, err
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		shErr = eachRowCols(sf2, []string{"shape_id", "shape_pt_lat",
+			"shape_pt_lon", "shape_pt_sequence"},
+			func(v []string) {
+				if keep != nil && !shapeNeeded[v[0]] {
+					return
+				}
+				lat, e1 := strconv.ParseFloat(v[1], 64)
+				lon, e2 := strconv.ParseFloat(v[2], 64)
+				seq, e3 := strconv.Atoi(v[3])
+				if e1 == nil && e2 == nil && e3 == nil {
+					shapes[v[0]] = append(shapes[v[0]], spt{seq, geo.LL{Lon: lon, Lat: lat}})
+				}
+			})
+	}()
+	wg.Wait()
+	if stErr != nil {
+		return nil, stErr
+	}
+	if shErr != nil {
+		return nil, shErr
 	}
 	for id := range shapes {
 		s := shapes[id]
@@ -358,6 +410,57 @@ func exciseLoops(pts []geo.LL, stops []geo.LL) []geo.LL {
 		}
 	}
 	return pts
+}
+
+// eachRowCols streams a CSV member resolving the wanted columns to indices
+// once, with csv.ReuseRecord (field strings are substrings of a fresh
+// per-record backing string, so retaining them is safe). Missing columns
+// and short rows read as "" — the same fallback eachRow's get() applies.
+func eachRowCols(f *zip.File, cols []string, fn func(vals []string)) error {
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	r := csv.NewReader(rc)
+	r.FieldsPerRecord = -1
+	r.LazyQuotes = true
+	r.ReuseRecord = true
+	header, err := r.Read()
+	if err != nil {
+		return err
+	}
+	if len(header) > 0 && len(header[0]) > 2 && header[0][0] == 0xEF {
+		header[0] = header[0][3:]
+	}
+	idxs := make([]int, len(cols))
+	for j, c := range cols {
+		idxs[j] = -1
+		for i, h := range header {
+			if h == c {
+				idxs[j] = i
+				break
+			}
+		}
+	}
+	vals := make([]string, len(cols))
+	for {
+		row, err := r.Read()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for j, ix := range idxs {
+			if ix < 0 || ix >= len(row) {
+				vals[j] = ""
+			} else {
+				vals[j] = row[ix]
+			}
+		}
+		fn(vals)
+	}
 }
 
 func eachRow(f *zip.File, fn func(get func(string) string)) error {

--- a/internal/gtfs/gtfs.go
+++ b/internal/gtfs/gtfs.go
@@ -206,8 +206,22 @@ func Load(path string, coverFrac float64) (*Feed, error) {
 			Route: r, ShapeID: k.shape, Trips: n, Shape: pts,
 		})
 	}
-	for _, pats := range byRoute {
-		sort.Slice(pats, func(i, j int) bool { return pats[i].Trips > pats[j].Trips })
+	// deterministic route order and trip-count tie-break: map iteration and
+	// an unstable sort let equal-trip patterns swap runs, flipping which
+	// shapes make the coverage cut (and every downstream emission order)
+	routeIDs := make([]string, 0, len(byRoute))
+	for rid := range byRoute {
+		routeIDs = append(routeIDs, rid)
+	}
+	sort.Strings(routeIDs)
+	for _, rid := range routeIDs {
+		pats := byRoute[rid]
+		sort.Slice(pats, func(i, j int) bool {
+			if pats[i].Trips != pats[j].Trips {
+				return pats[i].Trips > pats[j].Trips
+			}
+			return pats[i].ShapeID < pats[j].ShapeID
+		})
 		total := 0
 		for _, p := range pats {
 			total += p.Trips

--- a/internal/gtfs/gtfs.go
+++ b/internal/gtfs/gtfs.go
@@ -194,6 +194,7 @@ func LoadFiltered(path string, coverFrac float64, keep func(Route) bool) (*Feed,
 	}
 	sf2, err := need("shapes.txt")
 	if err != nil {
+		wg.Wait() // the stop_times goroutine must not outlive the zip close
 		return nil, err
 	}
 	wg.Add(1)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -165,14 +165,21 @@ func Chart(o ChartOpts, logf func(string, ...any)) error {
 	if o.Scenario != "" {
 		loadCover = 1.01 // scenario selection replaces union pruning
 	}
-	feed, err := gtfs.Load(o.GTFS, loadCover)
+	// rail filter at the load: the stop_times sweep (5.8M rows on Chicago,
+	// ~95% bus) skips foreign trips with one map miss, and bus shapes never
+	// parse. The kept patterns are identical — the same predicate re-runs
+	// below on what used to be the full set.
+	isRail := func(r gtfs.Route) bool {
+		t := r.Type
+		return t == 0 || t == 1 || t == 2 || (t >= 100 && t < 200)
+	}
+	feed, err := gtfs.LoadFiltered(o.GTFS, loadCover, isRail)
 	if err != nil {
 		return err
 	}
 	var rail []gtfs.Pattern
 	for _, pat := range feed.Patterns {
-		t := pat.Route.Type
-		if t == 0 || t == 1 || t == 2 || (t >= 100 && t < 200) {
+		if isRail(pat.Route) {
 			rail = append(rail, pat)
 		}
 	}

--- a/internal/stages/bundle_edges.go
+++ b/internal/stages/bundle_edges.go
@@ -2,6 +2,7 @@ package stages
 
 import (
 	"math"
+	"sort"
 
 	"github.com/alexwohlbruck/portolan/internal/bundle"
 	"github.com/alexwohlbruck/portolan/internal/geo"
@@ -40,6 +41,7 @@ var (
 const (
 	mergeSnap   = 30.0 // interval ends this close to an edge end snap to it
 	mergeRounds = 600  // safety bound (each round applies ONE merge)
+	mergeDS     = 8.0  // a-sample spacing for all pair evaluations
 )
 
 // looseTwins gates the short-fragment twin merge to a second phase: it is
@@ -53,16 +55,17 @@ func bundleParallelEdges(net *Network) int {
 	mergeRun = dial("split_merge_run", 60)
 	coMergeDist = dial("split_co_merge_dist", 4)
 	merges := 0
+	st := newBundleState(net)
 	looseTwins = false
 	for round := 0; round < mergeRounds; round++ {
-		if !mergeOnePair(net) {
+		if !mergeOnePair(net, st) {
 			break
 		}
 		merges++
 	}
 	looseTwins = true
 	for round := 0; round < mergeRounds; round++ {
-		if !mergeOnePair(net) {
+		if !mergeOnePair(net, st) {
 			break
 		}
 		merges++
@@ -83,8 +86,6 @@ func rebuildAdj(net *Network) {
 	}
 }
 
-// mergeOnePair finds one sustained-parallel edge pair and applies the cut +
-// merge. Returns false when the network has no more mergeable pairs.
 // level index: vertical class lookup for merge rules. A stacked pair (el
 // over subway) flattens to one trench in plan view but is NOT one
 // corridor — Apple keeps the Astoria el separate from Queens Blvd.
@@ -174,13 +175,147 @@ func sameLevel(net *Network, a, b int, lb *geo.Line, samples []geo.Pt, i, j int)
 	return differ <= agree
 }
 
-func mergeOnePair(net *Network) bool {
-	lines := make([]*geo.Line, len(net.Edges))
-	for i, e := range net.Edges {
-		lines[i] = geo.NewLine(e.Pts)
+// bundleState carries exact bookkeeping across mergeOnePair rounds. Each
+// round used to rebuild every line, resample every edge and re-evaluate
+// every candidate pair from scratch, apply ONE merge and start over — the
+// pipeline's single most expensive loop. Three invariants make the caching
+// exact:
+//
+//   - a NEGATIVE pair evaluation mutates nothing and depends only on the
+//     two edges' frozen content (Pts/Routes/Gap, keyed by id — content
+//     changes mint fresh ids), their CURRENT From/To node ids (welds
+//     change them, so they are part of the memo key) and the looseTwins
+//     phase — skip it for good once seen;
+//   - an edge's candidate list (nearby edges + per-sample counts) depends
+//     only on pair geometries, so it survives every round whose merge
+//     stayed out of the edge's 25 m sample neighborhood;
+//   - the level index and dials are constant per invocation.
+type bundleState struct {
+	nextID  int64
+	ids     []int64 // parallel to net.Edges
+	lines   map[int64]*geo.Line
+	samples map[int64][]geo.Pt // Resample(mergeDS)
+	cand    map[int64][]candEntry
+	neg     map[pairKey]struct{}
+	fresh   []int64      // ids minted by the last merge
+	dirty   [][]geo.Pt   // removed/new sample sets: neighborhoods to re-enumerate
+	arr     []*geo.Line  // per round: lines in current edge order
+	grid    *geo.Grid    // per round: spatial hash over arr
+	idIdx   map[int64]int
+}
+
+type candEntry struct {
+	id    int64
+	count int
+}
+
+type pairKey struct {
+	ida, idb int64
+	fa, ta   int
+	fb, tb   int
+	loose    bool
+}
+
+func newBundleState(net *Network) *bundleState {
+	st := &bundleState{
+		lines:   map[int64]*geo.Line{},
+		samples: map[int64][]geo.Pt{},
+		cand:    map[int64][]candEntry{},
+		neg:     map[pairKey]struct{}{},
+		idIdx:   map[int64]int{},
 	}
-	grid := geo.NewGrid(lines, 64)
-	const ds = 8.0
+	st.ids = make([]int64, len(net.Edges))
+	for i := range st.ids {
+		st.ids[i] = st.mint()
+	}
+	return st
+}
+
+func (st *bundleState) mint() int64 { st.nextID++; return st.nextID }
+
+func (st *bundleState) beginRound(net *Network) {
+	for i, id := range st.ids {
+		if st.lines[id] == nil {
+			l := geo.NewLine(net.Edges[i].Pts)
+			st.lines[id] = l
+			st.samples[id] = l.Resample(mergeDS)
+		}
+	}
+	st.arr = st.arr[:0]
+	for _, id := range st.ids {
+		st.arr = append(st.arr, st.lines[id])
+	}
+	st.grid = geo.NewGrid(st.arr, 64)
+	clear(st.idIdx)
+	for i, id := range st.ids {
+		st.idIdx[id] = i
+	}
+	// new geometry invalidates neighborhoods exactly like removed geometry
+	for _, id := range st.fresh {
+		st.dirty = append(st.dirty, st.samples[id])
+	}
+	st.fresh = st.fresh[:0]
+	// An edge's cached candidate list changes only if geometry appeared or
+	// vanished within 25 m of one of its samples. Any such sample lies on
+	// the edge's polyline within 25+4 m of some mergeDS=8 m sample of the
+	// changed geometry (Resample keeps endpoints, so every point of a line
+	// is ≤4 m of arc from a sample) — reach 30 marks a superset of the
+	// affected edges, and over-invalidation merely recomputes identical
+	// lists.
+	if len(st.dirty) > 0 {
+		aff := map[int]bool{}
+		for _, pts := range st.dirty {
+			for _, q := range pts {
+				st.grid.Near(q, 30, func(li int) { aff[li] = true })
+			}
+		}
+		for li := range aff {
+			delete(st.cand, st.ids[li])
+		}
+		st.dirty = st.dirty[:0]
+	}
+}
+
+// candFor returns edge a's candidate list — every edge with ≥1 a-sample
+// within 25 m, with the sample count — computing it (identically to the
+// old per-round enumeration) only when no valid cached list exists.
+func (st *bundleState) candFor(a int) []candEntry {
+	id := st.ids[a]
+	if c, ok := st.cand[id]; ok {
+		return c
+	}
+	counts := map[int]int{}
+	for _, q := range st.samples[id] {
+		// gap bridges DO merge into a real corridor they shadow — a
+		// bridged service running alongside ridden track is the same
+		// visual corridor (the FX express bridge on Culver); genuine
+		// gaps have no parallel corridor and are untouched
+		// candidate reach covers the banded-corridor width, not just
+		// the kiss range — the DeKalb bypass rides 10–25 m out
+		st.grid.Near(q, 25, func(b int) {
+			if b != a {
+				counts[b]++
+			}
+		})
+	}
+	list := make([]candEntry, 0, len(counts))
+	for b, n := range counts {
+		list = append(list, candEntry{st.ids[b], n})
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].id < list[j].id })
+	st.cand[id] = list
+	return list
+}
+
+// mergeOnePair finds one sustained-parallel edge pair and applies the cut +
+// merge. Returns false when the network has no more mergeable pairs. The
+// scan runs in ascending edge order with candidates in ascending edge
+// order — identical to the original full re-evaluation — with negative
+// pair decisions memoized (see bundleState).
+func mergeOnePair(net *Network, st *bundleState) bool {
+	st.beginRound(net)
+	lineOf := func(e int) *geo.Line { return st.lines[st.ids[e]] }
+	const ds = mergeDS
 	// sharedEnds: which of a's ends (From-side, To-side) coincide with an
 	// end of b — by node id or position. A shared junction is STRUCTURAL
 	// proof two edges belong to one corridor there, which licenses merges
@@ -189,10 +324,11 @@ func mergeOnePair(net *Network) bool {
 	sharedMatrix := func(a, b int) [2][2]bool {
 		const tol = 8.0
 		ea, eb := net.Edges[a], net.Edges[b]
+		la, lb := lineOf(a), lineOf(b)
 		aN := [2]int{ea.From, ea.To}
-		aP := [2]geo.Pt{lines[a].Pts[0], lines[a].Pts[len(lines[a].Pts)-1]}
+		aP := [2]geo.Pt{la.Pts[0], la.Pts[len(la.Pts)-1]}
 		bN := [2]int{eb.From, eb.To}
-		bP := [2]geo.Pt{lines[b].Pts[0], lines[b].Pts[len(lines[b].Pts)-1]}
+		bP := [2]geo.Pt{lb.Pts[0], lb.Pts[len(lb.Pts)-1]}
 		var out [2][2]bool
 		for i := 0; i < 2; i++ {
 			for j := 0; j < 2; j++ {
@@ -204,10 +340,11 @@ func mergeOnePair(net *Network) bool {
 		return out
 	}
 	endPt := func(e, end int) geo.Pt {
+		l := lineOf(e)
 		if end == 0 {
-			return lines[e].Pts[0]
+			return l.Pts[0]
 		}
-		return lines[e].Pts[len(lines[e].Pts)-1]
+		return l.Pts[len(l.Pts)-1]
 	}
 	// banded: topology-anchored corridor test — some shared end (i,j) with
 	// the OPPOSITE ends in the same junction cluster, comparable lengths,
@@ -217,7 +354,7 @@ func mergeOnePair(net *Network) bool {
 		if net.Edges[a].Gap || net.Edges[b].Gap {
 			return false
 		}
-		la, lb := lines[a].Len(), lines[b].Len()
+		la, lb := lineOf(a).Len(), lineOf(b).Len()
 		if la < mergeRun || lb < mergeRun ||
 			math.Abs(la-lb) > math.Max(40, 0.25*math.Max(la, lb)) {
 			return false
@@ -234,35 +371,36 @@ func mergeOnePair(net *Network) bool {
 			return false
 		}
 		in := 0
-		samples := lines[a].Resample(12)
+		samples := lineOf(a).Resample(12)
 		for _, q := range samples {
-			if lines[b].DistTo(q) <= bandMax {
+			if lineOf(b).WithinLE(q, bandMax) {
 				in++
 			}
 		}
 		return float64(in) >= 0.85*float64(len(samples))
 	}
 	for a := range net.Edges {
-		if net.Edges[a].Gap || lines[a].Len() < 20 {
+		if net.Edges[a].Gap || lineOf(a).Len() < 20 {
 			continue
 		}
-		samples := lines[a].Resample(ds)
-		nearCounts := map[int]int{}
-		for _, q := range samples {
-			// gap bridges DO merge into a real corridor they shadow — a
-			// bridged service running alongside ridden track is the same
-			// visual corridor (the FX express bridge on Culver); genuine
-			// gaps have no parallel corridor and are untouched
-			// candidate reach covers the banded-corridor width, not just
-			// the kiss range — the DeKalb bypass rides 10–25 m out
-			grid.Near(q, 25, func(b int) {
-				if b != a {
-					nearCounts[b]++
-				}
-			})
+		samples := st.samples[st.ids[a]]
+		type bc struct{ idx, count int }
+		var bs []bc
+		for _, ce := range st.candFor(a) {
+			if bi, ok := st.idIdx[ce.id]; ok {
+				bs = append(bs, bc{bi, ce.count})
+			}
 		}
-		bs := sortedKeys(nearCounts)
-		for _, b := range bs {
+		sort.Slice(bs, func(i, j int) bool { return bs[i].idx < bs[j].idx })
+		for _, cb := range bs {
+			b := cb.idx
+			key := pairKey{st.ids[a], st.ids[b],
+				net.Edges[a].From, net.Edges[a].To,
+				net.Edges[b].From, net.Edges[b].To, looseTwins}
+			if _, seen := st.neg[key]; seen {
+				continue
+			}
+			la, lb := lineOf(a), lineOf(b)
 			mat := sharedMatrix(a, b)
 			shared := [2]bool{mat[0][0] || mat[0][1], mat[1][0] || mat[1][1]}
 
@@ -277,7 +415,7 @@ func mergeOnePair(net *Network) bool {
 			// corridor merges these slivers are the last braid source.
 			twin := shared[0] && shared[1]
 			farMax := mergeDist
-			la2, lb2 := lines[a].Len(), lines[b].Len()
+			la2, lb2 := la.Len(), lb.Len()
 			if la2 < 80 && lb2 < 80 {
 				// short twins carry longitudinal end slack (their refined
 				// endpoints drift meters from the shared nodes) — that
@@ -286,22 +424,24 @@ func mergeOnePair(net *Network) bool {
 				farMax = math.Max(mergeDist, math.Min(20, 0.4*math.Min(la2, lb2)))
 				if !twin && looseTwins && !net.Edges[b].Gap {
 					tol := math.Min(20, 0.4*math.Min(la2, lb2))
-					aP0, aP1 := lines[a].Pts[0], lines[a].Pts[len(lines[a].Pts)-1]
-					bP0, bP1 := lines[b].Pts[0], lines[b].Pts[len(lines[b].Pts)-1]
+					aP0, aP1 := la.Pts[0], la.Pts[len(la.Pts)-1]
+					bP0, bP1 := lb.Pts[0], lb.Pts[len(lb.Pts)-1]
 					twin = (aP0.Dist(bP0) <= tol && aP1.Dist(bP1) <= tol) ||
 						(aP0.Dist(bP1) <= tol && aP1.Dist(bP0) <= tol)
 				}
 			}
 			if twin && !net.Edges[b].Gap {
-				far := 0.0
+				// far <= farMax  ⟺  every sample within farMax of b
+				within := true
 				for _, q := range samples {
-					if d := lines[b].DistTo(q); d > far {
-						far = d
+					if !lb.WithinLE(q, farMax) {
+						within = false
+						break
 					}
 				}
-				if far <= farMax &&
-					lvlOK(net, a, b, lines[a], lines[b], samples, 0, len(samples)-1) &&
-					applyMerge(net, a, b, 0, lines[a].Len(), 10) {
+				if within &&
+					lvlOK(net, a, b, la, lb, samples, 0, len(samples)-1) &&
+					applyMerge(net, st, a, b, 0, la.Len(), 10) {
 					return true
 				}
 			}
@@ -317,8 +457,8 @@ func mergeOnePair(net *Network) bool {
 			// Distinct corridors that merely kiss (Rector) or nest
 			// (South Ferry loops) never share junctions.
 			if banded(a, b, mat) &&
-				lvlOK(net, a, b, lines[a], lines[b], samples, 0, len(samples)-1) {
-				if applyMerge(net, a, b, 0, lines[a].Len(), 10) {
+				lvlOK(net, a, b, la, lb, samples, 0, len(samples)-1) {
+				if applyMerge(net, st, a, b, 0, la.Len(), 10) {
 					return true
 				}
 			}
@@ -333,25 +473,46 @@ func mergeOnePair(net *Network) bool {
 			// headings must agree throughout, and the tail's far quarter
 			// must hold a STABLE separation (a crossing's profile is a V,
 			// never a plateau).
-			if !net.Edges[a].Gap && !net.Edges[b].Gap &&
+			// A qualifying run needs ≥ corrRun/ds samples within
+			// corrBand — and corrBand equals the candidate reach, so the
+			// cached count is a provably-necessary cheap gate.
+			if float64(cb.count)*ds >= corrRun &&
+				!net.Edges[a].Gap && !net.Edges[b].Gap &&
 				!edgeRoutesIntersect(net.Edges[a].Routes, net.Edges[b].Routes) &&
-				lines[a].Len() >= corrRun {
+				la.Len() >= corrRun {
 				dists := make([]float64, len(samples))
-				headok := make([]bool, len(samples))
+				arcs := make([]float64, len(samples))
 				for i, q := range samples {
-					arcB, d := lines[b].ProjectArc(q)
-					dists[i] = d
-					ta := lines[a].TangentAtArc(float64(i)*ds, 15)
-					tb := lines[b].TangentAtArc(arcB, 15)
-					headok[i] = math.Abs(ta.Dot(tb)) >= corrHead
+					// exact whenever the value can be ≤ corrBand; +Inf
+					// stands in when the true distance exceeds the cap
+					// (the comparisons below agree either way)
+					arcB, d, ok := lb.ProjectArcCapped(q, corrBand+1)
+					if !ok {
+						dists[i] = math.Inf(1)
+						continue
+					}
+					dists[i], arcs[i] = d, arcB
+				}
+				// heading agreement, computed only where it is read
+				// (dists ≤ corrBand — the arc is exact there)
+				headok := make([]bool, len(samples))
+				headSet := make([]bool, len(samples))
+				headAt := func(i int) bool {
+					if !headSet[i] {
+						ta := la.TangentAtArc(float64(i)*ds, 15)
+						tb := lb.TangentAtArc(arcs[i], 15)
+						headok[i] = math.Abs(ta.Dot(tb)) >= corrHead
+						headSet[i] = true
+					}
+					return headok[i]
 				}
 				for i := 0; i < len(samples); {
-					if dists[i] > corrBand || !headok[i] {
+					if dists[i] > corrBand || !headAt(i) {
 						i++
 						continue
 					}
 					j, anchor := i, -1
-					for j < len(samples) && dists[j] <= corrBand && headok[j] {
+					for j < len(samples) && dists[j] <= corrBand && headAt(j) {
 						if dists[j] <= corrAnchor &&
 							(anchor < 0 || dists[j] < dists[anchor]) {
 							anchor = j
@@ -372,8 +533,8 @@ func mergeOnePair(net *Network) bool {
 							mx = math.Max(mx, dists[k])
 						}
 						if mx-mn <= 6 &&
-							lvlOK(net, a, b, lines[a], lines[b], samples, i, j) &&
-							applyMerge(net, a, b, float64(i)*ds, float64(j-1)*ds) {
+							lvlOK(net, a, b, la, lb, samples, i, j) &&
+							applyMerge(net, st, a, b, float64(i)*ds, float64(j-1)*ds) {
 							return true
 						}
 					}
@@ -381,9 +542,9 @@ func mergeOnePair(net *Network) bool {
 				}
 			}
 
-
-			cnt := nearCounts[b]
+			cnt := cb.count
 			if float64(cnt)*ds < mergeRun {
+				st.neg[key] = struct{}{}
 				continue
 			}
 			// SAME-SERVICE doubling (directional splits, terminal V-legs)
@@ -404,12 +565,12 @@ func mergeOnePair(net *Network) bool {
 			// (that late start is what braided G with A/C on Fulton and
 			// blue/orange below W 4 St). From the shared end, take the
 			// run within the full kiss range.
-			if disjoint && (shared[0] || shared[1]) && lines[a].Len() >= mergeRun {
+			if disjoint && (shared[0] || shared[1]) && la.Len() >= mergeRun {
 				try := func(fromStart bool) bool {
 					run := 0
 					if fromStart {
 						for _, q := range samples {
-							if lines[b].DistTo(q) > mergeDist {
+							if !lb.WithinLE(q, mergeDist) {
 								break
 							}
 							run++
@@ -417,13 +578,13 @@ func mergeOnePair(net *Network) bool {
 						if float64(run)*ds < mergeRun {
 							return false
 						}
-						if !lvlOK(net, a, b, lines[a], lines[b], samples, 0, run-1) {
+						if !lvlOK(net, a, b, la, lb, samples, 0, run-1) {
 							return false
 						}
-						return applyMerge(net, a, b, 0, float64(run-1)*ds)
+						return applyMerge(net, st, a, b, 0, float64(run-1)*ds)
 					}
 					for i := len(samples) - 1; i >= 0; i-- {
-						if lines[b].DistTo(samples[i]) > mergeDist {
+						if !lb.WithinLE(samples[i], mergeDist) {
 							break
 						}
 						run++
@@ -431,11 +592,11 @@ func mergeOnePair(net *Network) bool {
 					if float64(run)*ds < mergeRun {
 						return false
 					}
-					if !lvlOK(net, a, b, lines[a], lines[b], samples, len(samples)-run, len(samples)-1) {
+					if !lvlOK(net, a, b, la, lb, samples, len(samples)-run, len(samples)-1) {
 						return false
 					}
-					return applyMerge(net, a, b,
-						float64(len(samples)-run)*ds, lines[a].Len())
+					return applyMerge(net, st, a, b,
+						float64(len(samples)-run)*ds, la.Len())
 				}
 				if shared[0] && try(true) {
 					return true
@@ -448,7 +609,7 @@ func mergeOnePair(net *Network) bool {
 			// longest sustained run of a-samples within reach of b
 			best, cur, curStart, bestStart := 0, 0, 0, 0
 			for i, q := range samples {
-				if lines[b].DistTo(q) <= reach {
+				if lb.WithinLE(q, reach) {
 					if cur == 0 {
 						curStart = i
 					}
@@ -461,16 +622,19 @@ func mergeOnePair(net *Network) bool {
 				}
 			}
 			if float64(best)*ds < mergeRun {
+				st.neg[key] = struct{}{}
 				continue
 			}
 			a1 := float64(bestStart) * ds
 			a2 := float64(bestStart+best-1) * ds
-			if !lvlOK(net, a, b, lines[a], lines[b], samples, bestStart, bestStart+best-1) {
+			if !lvlOK(net, a, b, la, lb, samples, bestStart, bestStart+best-1) {
+				st.neg[key] = struct{}{}
 				continue
 			}
-			if applyMerge(net, a, b, a1, a2) {
+			if applyMerge(net, st, a, b, a1, a2) {
 				return true
 			}
+			st.neg[key] = struct{}{}
 		}
 	}
 	return false
@@ -483,13 +647,13 @@ var mergeLog func(format string, args ...any)
 // overlapping middles with one union edge on the midpoint geometry.
 // minSpan overrides the default minimum merged length (node-pair twins
 // merge however short they are).
-func applyMerge(net *Network, a, b int, a1, a2 float64, minSpan ...float64) bool {
+func applyMerge(net *Network, st *bundleState, a, b int, a1, a2 float64, minSpan ...float64) bool {
 	minLen := mergeRun * 0.8
 	if len(minSpan) > 0 {
 		minLen = minSpan[0]
 	}
-	la := geo.NewLine(net.Edges[a].Pts)
-	lb := geo.NewLine(net.Edges[b].Pts)
+	la := st.lines[st.ids[a]]
+	lb := st.lines[st.ids[b]]
 	// snap interval ends onto edge ends
 	if a1 < mergeSnap {
 		a1 = 0
@@ -542,8 +706,8 @@ func applyMerge(net *Network, a, b int, a1, a2 float64, minSpan ...float64) bool
 	mid := bundle.SubLine(la, a1, a2)
 	var mpts []geo.Pt
 	for _, q := range mid.Resample(6) {
-		arc, d := lb.ProjectArc(q)
-		if d > mergeDist*1.5 {
+		arc, d, ok := lb.ProjectArcCapped(q, mergeDist*1.5+1)
+		if !ok || d > mergeDist*1.5 {
 			mpts = append(mpts, q)
 			continue
 		}
@@ -656,16 +820,37 @@ func applyMerge(net *Network, a, b int, a1, a2 float64, minSpan ...float64) bool
 			net.Edges[b].Routes, lb.Len(), tb1, tb2, rev,
 			len(newEdges), geo.NewLine(mpts).Len(), mpts[0].X, mpts[0].Y)
 	}
-	// splice: drop a and b, add the parts + merged corridor
+	// splice: drop a and b, add the parts + merged corridor — and mirror
+	// the id bookkeeping (survivors keep ids; parts + merged mint fresh
+	// ones; the removed and added sample sets drive cand invalidation)
+	oldA, oldB := st.ids[a], st.ids[b]
+	st.dirty = append(st.dirty, st.samples[oldA], st.samples[oldB])
 	var out []Edge
+	newIDs := make([]int64, 0, len(net.Edges)+len(newEdges)-1)
 	for ei, e := range net.Edges {
 		if ei != a && ei != b {
 			out = append(out, e)
+			newIDs = append(newIDs, st.ids[ei])
 		}
 	}
 	out = append(out, newEdges...)
+	for range newEdges {
+		id := st.mint()
+		newIDs = append(newIDs, id)
+		st.fresh = append(st.fresh, id)
+	}
 	out = append(out, merged)
+	mid2 := st.mint()
+	newIDs = append(newIDs, mid2)
+	st.fresh = append(st.fresh, mid2)
 	net.Edges = out
+	st.ids = newIDs
+	delete(st.lines, oldA)
+	delete(st.lines, oldB)
+	delete(st.samples, oldA)
+	delete(st.samples, oldB)
+	delete(st.cand, oldA)
+	delete(st.cand, oldB)
 	return true
 }
 
@@ -714,19 +899,4 @@ func sortStrings(v []string) {
 			v[j], v[j-1] = v[j-1], v[j]
 		}
 	}
-}
-
-var _ = math.Abs
-
-func sortedKeys(m map[int]int) []int {
-	var out []int
-	for k := range m {
-		out = append(out, k)
-	}
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j] < out[j-1]; j-- {
-			out[j], out[j-1] = out[j-1], out[j]
-		}
-	}
-	return out
 }

--- a/internal/stages/bundle_edges.go
+++ b/internal/stages/bundle_edges.go
@@ -257,16 +257,16 @@ func (st *bundleState) beginRound(net *Network) {
 	st.fresh = st.fresh[:0]
 	// An edge's cached candidate list changes only if geometry appeared or
 	// vanished within 25 m of one of its samples. Any such sample lies on
-	// the edge's polyline within 25+4 m of some mergeDS=8 m sample of the
-	// changed geometry (Resample keeps endpoints, so every point of a line
-	// is ≤4 m of arc from a sample) — reach 30 marks a superset of the
-	// affected edges, and over-invalidation merely recomputes identical
-	// lists.
+	// the edge's polyline within 25+6 m of some sample of the changed
+	// geometry (Resample keeps endpoints and rounds the count, so arc gaps
+	// reach 12 m on lines just over 10 m — slack 6 m, not mergeDS/2) —
+	// reach 31 marks a superset of the affected edges, and
+	// over-invalidation merely recomputes identical lists.
 	if len(st.dirty) > 0 {
 		aff := map[int]bool{}
 		for _, pts := range st.dirty {
 			for _, q := range pts {
-				st.grid.Near(q, 30, func(li int) { aff[li] = true })
+				st.grid.Near(q, 31, func(li int) { aff[li] = true })
 			}
 		}
 		for li := range aff {

--- a/internal/stages/fair.go
+++ b/internal/stages/fair.go
@@ -972,6 +972,17 @@ func straightenCone(pts []geo.Pt, tol, coneDot float64) []geo.Pt {
 	if len(pts) < 3 {
 		return pts
 	}
+	// per-segment norm/unit depend only on k, not the chord: compute once
+	// (identical operands and guard order as the inline computation)
+	segN := make([]float64, len(pts)-1)
+	segU := make([]geo.Pt, len(pts)-1)
+	for k := range segN {
+		seg := pts[k+1].Sub(pts[k])
+		segN[k] = seg.Norm()
+		if segN[k] > 1e-9 {
+			segU[k] = seg.Unit()
+		}
+	}
 	out := []geo.Pt{pts[0]}
 	i := 0
 	for i < len(pts)-1 {
@@ -990,8 +1001,7 @@ func straightenCone(pts []geo.Pt, tol, coneDot float64) []geo.Pt {
 				}
 			}
 			for k := i; k < j && ok; k++ {
-				seg := pts[k+1].Sub(pts[k])
-				if seg.Norm() > 1e-9 && seg.Unit().Dot(u) < coneDot {
+				if segN[k] > 1e-9 && segU[k].Dot(u) < coneDot {
 					ok = false
 				}
 			}

--- a/internal/stages/fair.go
+++ b/internal/stages/fair.go
@@ -388,7 +388,15 @@ func Fair(n *Network, slots map[int][]string, routes map[string]gtfs.Route, path
 		}
 		var cands []cand
 		for ni := range n.Nodes {
-			for color, prs := range throughs[ni] {
+			// sorted color order: map iteration here decides segment emission
+			// order, which must not vary run to run
+			colors := make([]string, 0, len(throughs[ni]))
+			for color := range throughs[ni] {
+				colors = append(colors, color)
+			}
+			sort.Strings(colors)
+			for _, color := range colors {
+				prs := throughs[ni][color]
 				for _, pr := range prs {
 					a, b := pr.a, pr.b
 					aAtTo := n.Edges[a].To == ni
@@ -670,7 +678,13 @@ func Fair(n *Network, slots map[int][]string, routes map[string]gtfs.Route, path
 		// the end of geometry)
 		for ei, e := range n.Edges {
 			l := lines[ei]
+			// sorted color order: emission order must not vary run to run
+			colors := make([]string, 0, len(colorRoutes[ei]))
 			for color := range colorRoutes[ei] {
+				colors = append(colors, color)
+			}
+			sort.Strings(colors)
+			for _, color := range colors {
 				ci := colorIdx(ei, color)
 				if absorbed[[2]int{ei, ci}] {
 					continue // fully covered by a chained transition

--- a/internal/stages/graph.go
+++ b/internal/stages/graph.go
@@ -3,6 +3,7 @@ package stages
 import (
 	"fmt"
 	"math"
+	"sync"
 
 	"github.com/alexwohlbruck/portolan/internal/bundle"
 	"github.com/alexwohlbruck/portolan/internal/geo"
@@ -39,6 +40,27 @@ type tgEdge struct {
 func (g *trackGraph) rev(e int) int { return e ^ 1 }
 
 const weldEps = 0.6 // m; OSM shared nodes survive GeoJSON at cm precision
+
+// Match and Split build the graph from the same tracks slice and already
+// rely on the two builds being identical (shared piece ids) — build once.
+// Keyed on slice identity: any other slice rebuilds.
+var (
+	graphCacheMu sync.Mutex
+	cachedTracks []bundle.Track
+	cachedGraph  *trackGraph
+)
+
+func buildTrackGraphCached(tracks []bundle.Track) *trackGraph {
+	graphCacheMu.Lock()
+	defer graphCacheMu.Unlock()
+	if cachedGraph != nil && len(tracks) > 0 && len(tracks) == len(cachedTracks) &&
+		&tracks[0] == &cachedTracks[0] {
+		return cachedGraph
+	}
+	g := buildTrackGraph(tracks)
+	cachedTracks, cachedGraph = tracks, g
+	return g
+}
 
 // buildTrackGraph welds ways into a routable graph. Deterministic for a given
 // track slice — MATCH and SPLIT rebuild the same graph and share piece ids.

--- a/internal/stages/graph.go
+++ b/internal/stages/graph.go
@@ -14,10 +14,13 @@ import (
 // split there. Edges are way pieces between nodes; every piece appears as two
 // directed edges.
 type trackGraph struct {
-	nodes  []tgNode
-	edges  []tgEdge // directed; edges[2p] and edges[2p+1] are piece p
-	pieces []*geo.Line
-	grid   *geo.Grid // indexes pieces (line index == piece id)
+	nodes   []tgNode
+	edges   []tgEdge // directed; edges[2p] and edges[2p+1] are piece p
+	pieces  []*geo.Line
+	grid    *geo.Grid   // indexes pieces (line index == piece id)
+	turn    [][]float64 // turnDeg per directed edge, aligned with To-node's Out
+	isXover []bool      // crossoverWays[edge.Way], snapshotted at build
+	lvl     []int       // wayLevels[edge.Way], snapshotted at build
 }
 
 type tgNode struct {
@@ -136,6 +139,22 @@ func buildTrackGraph(tracks []bundle.Track) *trackGraph {
 	}
 	g.healBreaks()
 	g.grid = geo.NewGrid(g.pieces, 64)
+	// walk() tables: per-expansion turn angles and way-class lookups are
+	// pure functions of immutable graph geometry and the (already set)
+	// crossover/level registries — computed once, identical values
+	g.turn = make([][]float64, len(g.edges))
+	g.isXover = make([]bool, len(g.edges))
+	g.lvl = make([]int, len(g.edges))
+	for e := range g.edges {
+		g.isXover[e] = crossoverWays[g.edges[e].Way]
+		g.lvl[e] = wayLevels[g.edges[e].Way]
+		outs := g.nodes[g.edges[e].To].Out
+		t := make([]float64, len(outs))
+		for i, b := range outs {
+			t[i] = g.turnDeg(e, b)
+		}
+		g.turn[e] = t
+	}
 	return g
 }
 

--- a/internal/stages/match.go
+++ b/internal/stages/match.go
@@ -171,6 +171,24 @@ type matcher struct {
 	usedBy    map[int]map[string]bool // piece → route ids that ride it
 	usedColor map[int]map[string]bool // piece → colors that ride it
 	walks     map[[2]int]walkRes
+	ws        walkScratch // walk() is serial (Viterbi + assemble): safe to reuse
+}
+
+// walkScratch replaces walk()'s per-call map and slice allocations with
+// epoch-stamped arrays — same membership answers, same values, no churn.
+type walkScratch struct {
+	cost, wlen []float64
+	stamp      []uint32
+	epoch      uint32
+	arena      []wlabel
+	pq         walkPQ
+}
+
+type wlabel struct {
+	edge    int
+	prevIdx int
+	cost    float64
+	walkLen float64
 }
 
 type walkRes struct {
@@ -304,7 +322,7 @@ func (m *matcher) matchOne(pat gtfs.Pattern, frame geo.Frame) (Path, bool) {
 		if seg <= denseSpacing {
 			return 1, 0
 		}
-		return math.Max(0.05, denseSpacing / seg), math.Min(400, seg/2)
+		return math.Max(0.05, denseSpacing/seg), math.Min(400, seg/2)
 	}
 
 	// candidates + emissions per sample; the gap gate closes wherever a
@@ -437,16 +455,23 @@ func (m *matcher) walk(u, v int, maxWalk float64) walkRes {
 	// pairs whenever the cheap path was the long way round. Each label
 	// carries its own parent chain — a shared prev map would splice
 	// fragments of different paths into broken geometry.
-	type label struct {
-		edge    int
-		prevIdx int
-		cost    float64
-		walkLen float64
+	ws := &m.ws
+	if len(ws.stamp) < len(g.edges) {
+		ws.cost = make([]float64, len(g.edges))
+		ws.wlen = make([]float64, len(g.edges))
+		ws.stamp = make([]uint32, len(g.edges))
 	}
-	arena := []label{{edge: u, prevIdx: -1}}
-	type bestPair struct{ cost, walkLen float64 }
-	best := map[int]bestPair{u: {}}
-	pq := &walkPQ{{edge: u}}
+	ws.epoch++
+	if ws.epoch == 0 { // wrapped: stale stamps could alias the new epoch
+		clear(ws.stamp)
+		ws.epoch = 1
+	}
+	epoch := ws.epoch
+	ws.arena = append(ws.arena[:0], wlabel{edge: u, prevIdx: -1})
+	arena := ws.arena
+	ws.pq = append(ws.pq[:0], walkItem{edge: u})
+	pq := &ws.pq
+	ws.stamp[u], ws.cost[u], ws.wlen[u] = epoch, 0, 0
 	for pq.Len() > 0 {
 		cur := heap.Pop(pq).(walkItem)
 		lab := arena[cur.labelIdx]
@@ -458,13 +483,15 @@ func (m *matcher) walk(u, v int, maxWalk float64) walkRes {
 			for i, j := 0, len(via)-1; i < j; i, j = i+1, j-1 {
 				via[i], via[j] = via[j], via[i]
 			}
+			ws.arena = arena
 			return walkRes{cost: lab.cost, via: via, ok: true}
 		}
-		if b, seen := best[lab.edge]; seen && lab.cost > b.cost && lab.walkLen > b.walkLen {
+		if ws.stamp[lab.edge] == epoch &&
+			lab.cost > ws.cost[lab.edge] && lab.walkLen > ws.wlen[lab.edge] {
 			continue
 		}
-		for _, nx := range g.nodes[g.edges[lab.edge].To].Out {
-			c := lab.cost + g.turnDeg(lab.edge, nx)*p.WTurn
+		for oi, nx := range g.nodes[g.edges[lab.edge].To].Out {
+			c := lab.cost + g.turn[lab.edge][oi]*p.WTurn
 			wl := lab.walkLen
 			if nx == g.rev(lab.edge) {
 				c += p.UTurnPen
@@ -472,10 +499,10 @@ func (m *matcher) walk(u, v int, maxWalk float64) walkRes {
 			if nx != v {
 				el := g.edges[nx].Line.Len()
 				c += el*p.WWalk + p.WHop
-				if crossoverWays[g.edges[nx].Way] {
+				if g.isXover[nx] {
 					c += crossoverPen
 				}
-				if wayLevels[g.edges[lab.edge].Way]*wayLevels[g.edges[nx].Way] < 0 {
+				if g.lvl[lab.edge]*g.lvl[nx] < 0 {
 					c += levelJumpPen
 				}
 				wl += el
@@ -483,19 +510,20 @@ func (m *matcher) walk(u, v int, maxWalk float64) walkRes {
 					continue
 				}
 			}
-			b, seen := best[nx]
-			if seen && c >= b.cost && wl >= b.walkLen {
-				continue // dominated
-			}
-			if !seen {
-				best[nx] = bestPair{c, wl}
+			if ws.stamp[nx] == epoch {
+				if c >= ws.cost[nx] && wl >= ws.wlen[nx] {
+					continue // dominated
+				}
+				ws.cost[nx] = math.Min(c, ws.cost[nx])
+				ws.wlen[nx] = math.Min(wl, ws.wlen[nx])
 			} else {
-				best[nx] = bestPair{math.Min(c, b.cost), math.Min(wl, b.walkLen)}
+				ws.stamp[nx], ws.cost[nx], ws.wlen[nx] = epoch, c, wl
 			}
-			arena = append(arena, label{edge: nx, prevIdx: cur.labelIdx, cost: c, walkLen: wl})
+			arena = append(arena, wlabel{edge: nx, prevIdx: cur.labelIdx, cost: c, walkLen: wl})
 			heap.Push(pq, walkItem{edge: nx, cost: c, walkLen: wl, labelIdx: len(arena) - 1})
 		}
 	}
+	ws.arena = arena
 	return walkRes{ok: false}
 }
 

--- a/internal/stages/match.go
+++ b/internal/stages/match.go
@@ -3,7 +3,9 @@ package stages
 import (
 	"container/heap"
 	"math"
+	"runtime"
 	"sort"
+	"sync"
 
 	"github.com/alexwohlbruck/portolan/internal/bundle"
 	"github.com/alexwohlbruck/portolan/internal/geo"
@@ -182,6 +184,81 @@ type candidate struct {
 	emit float64 // emission cost at this sample
 }
 
+// emitSample computes one sample's candidate list and gap emission — the
+// body of the old per-sample loop, verbatim. It reads only immutable state
+// (graph, grid, params, usedBy/usedColor between assembles) and writes
+// only its own index, so samples run concurrently with identical results.
+func (m *matcher) emitSample(pat gtfs.Pattern, q geo.Pt, i int, shape *geo.Line,
+	shapeArc func(int) float64, sampleConf func(float64) (float64, float64),
+	cands [][]candidate, gapEmit []float64) {
+
+	tan := shape.TangentAtArc(shapeArc(i), 15)
+	w, spread := sampleConf(shapeArc(i))
+	reach, maxCand := m.p.Reach, m.p.MaxCand
+	if spread > 0 {
+		reach += spread
+		maxCand += 8
+	}
+	type pc struct {
+		piece int
+		d     float64
+		arc   float64
+	}
+	var near []pc
+	m.g.grid.Near(q, reach, func(piece int) {
+		arc, d := m.g.pieces[piece].ProjectArc(q)
+		near = append(near, pc{piece, d, arc})
+	})
+	sort.Slice(near, func(a, b int) bool { return near[a].d < near[b].d })
+	if len(near) > maxCand {
+		near = near[:maxCand]
+	}
+	hasCompat := false
+	if wayRailClass != nil {
+		for _, c := range near {
+			if classCompat(pat.Route.Type, wayRailClass[m.g.edges[2*c.piece].Way]) {
+				hasCompat = true
+				break
+			}
+		}
+	}
+	usable := false
+	for _, c := range near {
+		compat := !hasCompat ||
+			classCompat(pat.Route.Type, wayRailClass[m.g.edges[2*c.piece].Way])
+		ptan := m.g.pieces[c.piece].TangentAtArc(c.arc, 10)
+		dot := ptan.Dot(tan)
+		if compat && c.d < m.p.GapFree && math.Abs(dot) >= 0.5 {
+			usable = true
+		}
+		bonus := 0.0
+		switch {
+		case m.usedBy[c.piece][pat.Route.ID]:
+			bonus = m.p.BonusRoute
+		case m.usedColor[c.piece][pat.Route.Color]:
+			bonus = m.p.BonusColor
+		case len(m.usedBy[c.piece]) > 0:
+			bonus = m.p.BonusOther
+		}
+		for dir := 0; dir <= 1; dir++ {
+			dd := dot
+			if dir == 1 {
+				dd = -dd
+			}
+			e := 2*c.piece + dir
+			pen := 0.0
+			if !compat {
+				pen = classPen
+			}
+			cands[i] = append(cands[i], candidate{e, w*(c.d+m.p.WHead*(1-dd)+pen) - bonus})
+		}
+	}
+	gapEmit[i] = barredGap
+	if !usable {
+		gapEmit[i] = m.p.GapCost
+	}
+}
+
 func (m *matcher) matchOne(pat gtfs.Pattern, frame geo.Frame) (Path, bool) {
 	pts := make([]geo.Pt, len(pat.Shape))
 	for i, ll := range pat.Shape {
@@ -233,75 +310,27 @@ func (m *matcher) matchOne(pat gtfs.Pattern, frame geo.Frame) (Path, bool) {
 	// candidates + emissions per sample; the gap gate closes wherever a
 	// usable (near, heading-aligned) track exists — GAP is for missing
 	// track, never a way to jump between parallel paths
+	// Per-sample work is independent and side-effect-free: usedBy/usedColor
+	// are only written by assemble AFTER the whole pattern resolves, the
+	// graph and grid are immutable here, and every result lands by index —
+	// so the samples fan out across workers with bit-identical results.
 	cands := make([][]candidate, n)
 	gapEmit := make([]float64, n)
-	for i, q := range samples {
-		tan := shape.TangentAtArc(shapeArc(i), 15)
-		w, spread := sampleConf(shapeArc(i))
-		reach, maxCand := m.p.Reach, m.p.MaxCand
-		if spread > 0 {
-			reach += spread
-			maxCand += 8
-		}
-		type pc struct {
-			piece int
-			d     float64
-			arc   float64
-		}
-		var near []pc
-		m.g.grid.Near(q, reach, func(piece int) {
-			arc, d := m.g.pieces[piece].ProjectArc(q)
-			near = append(near, pc{piece, d, arc})
-		})
-		sort.Slice(near, func(a, b int) bool { return near[a].d < near[b].d })
-		if len(near) > maxCand {
-			near = near[:maxCand]
-		}
-		hasCompat := false
-		if wayRailClass != nil {
-			for _, c := range near {
-				if classCompat(pat.Route.Type, wayRailClass[m.g.edges[2*c.piece].Way]) {
-					hasCompat = true
-					break
-				}
-			}
-		}
-		usable := false
-		for _, c := range near {
-			compat := !hasCompat ||
-				classCompat(pat.Route.Type, wayRailClass[m.g.edges[2*c.piece].Way])
-			ptan := m.g.pieces[c.piece].TangentAtArc(c.arc, 10)
-			dot := ptan.Dot(tan)
-			if compat && c.d < m.p.GapFree && math.Abs(dot) >= 0.5 {
-				usable = true
-			}
-			bonus := 0.0
-			switch {
-			case m.usedBy[c.piece][pat.Route.ID]:
-				bonus = m.p.BonusRoute
-			case m.usedColor[c.piece][pat.Route.Color]:
-				bonus = m.p.BonusColor
-			case len(m.usedBy[c.piece]) > 0:
-				bonus = m.p.BonusOther
-			}
-			for dir := 0; dir <= 1; dir++ {
-				dd := dot
-				if dir == 1 {
-					dd = -dd
-				}
-				e := 2*c.piece + dir
-				pen := 0.0
-				if !compat {
-					pen = classPen
-				}
-				cands[i] = append(cands[i], candidate{e, w*(c.d+m.p.WHead*(1-dd)+pen) - bonus})
-			}
-		}
-		gapEmit[i] = barredGap
-		if !usable {
-			gapEmit[i] = m.p.GapCost
-		}
+	var wg sync.WaitGroup
+	nw := runtime.NumCPU()
+	if nw > n {
+		nw = n
 	}
+	for wk := 0; wk < nw; wk++ {
+		wg.Add(1)
+		go func(wk int) {
+			defer wg.Done()
+			for i := wk; i < n; i += nw {
+				m.emitSample(pat, samples[i], i, shape, shapeArc, sampleConf, cands, gapEmit)
+			}
+		}(wk)
+	}
+	wg.Wait()
 
 	// Viterbi
 	type cell struct {
@@ -325,7 +354,15 @@ func (m *matcher) matchOne(pat gtfs.Pattern, frame geo.Frame) (Path, bool) {
 		for s, c := range dp[i-1] {
 			prevs = append(prevs, pv{s, c.cost})
 		}
-		sort.Slice(prevs, func(a, b int) bool { return prevs[a].cost < prevs[b].cost })
+		// state id breaks exact-cost ties: the old map-iteration order fed
+		// an unstable sort, which is run-to-run random exactly when a tie
+		// could matter
+		sort.Slice(prevs, func(a, b int) bool {
+			if prevs[a].cost != prevs[b].cost {
+				return prevs[a].cost < prevs[b].cost
+			}
+			return prevs[a].state < prevs[b].state
+		})
 
 		relax := func(state int, emit float64) {
 			best := math.Inf(1)
@@ -350,10 +387,11 @@ func (m *matcher) matchOne(pat gtfs.Pattern, frame geo.Frame) (Path, bool) {
 		relax(gapState, gapEmit[i])
 	}
 
-	// backtrack
+	// backtrack (smallest state id wins exact-cost ties — the map
+	// iteration here was run-to-run random exactly when a tie could matter)
 	last, best := gapState, math.Inf(1)
 	for s, c := range dp[n-1] {
-		if c.cost < best {
+		if c.cost < best || (c.cost == best && s < last) {
 			best, last = c.cost, s
 		}
 	}

--- a/internal/stages/match.go
+++ b/internal/stages/match.go
@@ -132,7 +132,7 @@ const levelJumpPen = 300.0
 // (short ways connecting longer ways: switches, median turns) penalized;
 // mainlines only — spurs and yards ignored except at station terminals.
 func Match(patterns []gtfs.Pattern, ways []bundle.Track, frame geo.Frame) ([]Path, error) {
-	g := buildTrackGraph(ways)
+	g := buildTrackGraphCached(ways)
 	p := defaultMatchParams()
 
 	// canonical patterns first: heaviest service defines the shared paths

--- a/internal/stages/order.go
+++ b/internal/stages/order.go
@@ -401,7 +401,19 @@ func Order(n *Network, routes map[string]gtfs.Route) (map[int][]string, error) {
 		}
 		return t
 	}
+	// sorted pair order: each accepted flip changes what later pairs see,
+	// so map iteration here made the whole pass run-to-run random
+	pairList := make([][2]string, 0, len(colorPairs))
 	for k := range colorPairs {
+		pairList = append(pairList, k)
+	}
+	sort.Slice(pairList, func(i, j int) bool {
+		if pairList[i][0] != pairList[j][0] {
+			return pairList[i][0] < pairList[j][0]
+		}
+		return pairList[i][1] < pairList[j][1]
+	})
+	for _, k := range pairList {
 		c1, c2 := k[0], k[1]
 		// union-find over edges carrying both colors, joined where the
 		// pair continues intact across a node
@@ -438,10 +450,23 @@ func Order(n *Network, routes map[string]gtfs.Route) (map[int][]string, error) {
 			}
 		}
 		comps := map[int][]int{}
+		compEdges := make([]int, 0, len(parent))
 		for ei := range parent {
+			compEdges = append(compEdges, ei)
+		}
+		sort.Ints(compEdges)
+		for _, ei := range compEdges {
 			comps[find(ei)] = append(comps[find(ei)], ei)
 		}
-		for _, edges := range comps {
+		// sorted component order: flips at shared nodes change what later
+		// components measure
+		roots := make([]int, 0, len(comps))
+		for r := range comps {
+			roots = append(roots, r)
+		}
+		sort.Ints(roots)
+		for _, r := range roots {
+			edges := comps[r]
 			nodes := map[int]bool{}
 			for _, ei := range edges {
 				nodes[n.Edges[ei].From] = true
@@ -484,7 +509,13 @@ func Order(n *Network, routes map[string]gtfs.Route) (map[int][]string, error) {
 		}
 		return out
 	}
+	// sorted color order: each accepted slide changes what later colors see
+	colorList := make([]string, 0, len(colorSet))
 	for c := range colorSet {
+		colorList = append(colorList, c)
+	}
+	sort.Strings(colorList)
+	for _, c := range colorList {
 		// component over edges carrying c, with relative storage
 		// orientation propagated across shared nodes (To→From aligned,
 		// To→To / From→From flipped) so "front" means one consistent
@@ -496,7 +527,14 @@ func Order(n *Network, routes map[string]gtfs.Route) (map[int][]string, error) {
 			}
 		}
 		visited := map[int]bool{}
+		// sorted seeds: the BFS tree (orientation propagation on cyclic
+		// components) and the component processing order both depend on it
+		seeds := make([]int, 0, len(inComp))
 		for seed := range inComp {
+			seeds = append(seeds, seed)
+		}
+		sort.Ints(seeds)
+		for _, seed := range seeds {
 			if visited[seed] {
 				continue
 			}

--- a/internal/stages/split.go
+++ b/internal/stages/split.go
@@ -957,7 +957,7 @@ func edgeTwins(cl *geo.Line, twinLines []*geo.Line, tgrid *geo.Grid) []*geo.Line
 	counts := map[int]int{}
 	for _, q := range samples {
 		tgrid.Near(q, twinMax, func(si int) {
-			if twinLines[si].DistTo(q) < twinMax {
+			if twinLines[si].Within(q, twinMax) {
 				counts[si]++
 			}
 		})

--- a/internal/stages/split.go
+++ b/internal/stages/split.go
@@ -61,7 +61,7 @@ func defaultSplitParams() splitParams {
 // segment the set of routes riding it.
 func Split(paths []Path, tracks []bundle.Track) (*Network, error) {
 	setLevelIndex(tracks)
-	g := buildTrackGraph(tracks)
+	g := buildTrackGraphCached(tracks)
 	p := defaultSplitParams()
 
 	// ---- usage: route set per used piece


### PR DESCRIPTION
NYC charts in **8.4s** instead of 124s (15×); Chicago in **4.6s** instead of 49s (11×). Every output byte is unchanged.

| | dev | this branch |
|---|---|---|
| NYC wall (median of 5) | 124.3s | **8.4s** |
| NYC user CPU | 173s | 25s |
| Chicago wall (median of 5) | 48.7s | **4.6s** |
| Chicago user CPU | 133s | 13.5s |
| peak RSS (NYC / Chicago) | 218 / 169 MB | 302 / 233 MB |
| `go test ./internal/stages` | 423s | 62s |

Measured on a 14-core Mac16,8, go1.26.5 darwin/arm64, sequential runs, GTFS + rail inputs on local disk.

## The contract

Byte-identical output was the gate, not a hope. After **every** commit: SHA-256 of all five emitted GeoJSON files per city (`.geojson`, `.nodes`, `.paths`, `.strands`, `.trackcenter`), NYC and Chicago, compared against a baseline frozen at `32752f8`. No commit landed without `GATE_PASS`.

Also verified on the final tree:

- `go test ./...` green.
- `go build -race` run of NYC: no races reported, output still byte-identical.
- 5 NYC + 3 Chicago repeated runs hash identically (run-to-run determinism — see below).
- `sound` scores unchanged (the 3 failing gates are pre-existing on dev).
- A 20-agent adversarial review of the full diff across four lenses (caching exactness, capped-query coverage, concurrency, future-regression fragility) produced 16 findings; **all 16 were refuted** under adversarial verification. One verifier instrumented the branch to replay dev's exact distance scans alongside the new ones over a complete NYC run: 5,388,709 `ProjectArc` + 13,772 `DistTo` calls, zero value flips, zero argmin flips. Three near-misses were hardened anyway in `f9d38dd`.

## dev was nondeterministic (fixed here)

Worth knowing independently of the perf work: **three runs of the pristine dev binary produce three different outputs.** Three separate causes, all map-iteration order leaking into results:

- `gtfs.Load` appended routes in map order under an unstable trip-count sort — equal-trip patterns swapped, flipping which shapes made the coverage cut.
- `Fair` emitted transition and steady segments in color-map order, shuffling `seg` indices.
- Rarest and worst: `Order`'s chain-consistency and slide-to-edge passes iterated `colorPairs` / `colorSet` / BFS seeds in map order, while **each accepted flip changes what later iterations measure** at shared nodes. Roughly 1 run in 10 diverged, flipping `off_from_px` signs on transition segments.

Fixed with sorted iteration throughout. The deterministic realization happens to equal the frozen baseline exactly, so the gate is meaningful rather than merely self-consistent.

Related landmine, now documented in a code comment: **`Grid.Near`'s visit order is load-bearing** — `FAIR`'s `trackCurveBetween` breaks connector-score ties by first visit, so the scan radius cannot be tightened even though a smaller one visits an identical set. Tightening it silently changed Chicago; that's why the `+1` stays.

## What actually got faster

Ordered by size of win. Each is exact by construction, not by tuning.

**`mergeOnePair` stops re-proving settled pairs** (`210e599`) — 64% of NYC's CPU, serial. It fired one merge per round and re-derived everything each round: every line, every resample, every candidate pair, up to 1200 rounds. Three invariants make caching exact: negative pair evaluations mutate nothing and are pure in (edge content id, current From/To node ids, `looseTwins` phase), so they memoize; candidate lists are pure in pair geometry, so they survive until a merge touches the edge's 25 m sample neighborhood; lines and samples key on content ids that only fresh edges mint. Scan order is untouched, so the same merges fire in the same sequence.

**Capped local queries** (`e56e844`, `f2928cd`) — 81% of Chicago's CPU. Every hot distance in `Refine` is a threshold test against a small cap (`Reach` 25 m, `twinMax` 6 m), which can be answered exactly while touching only local segments. `Line` grows a lazy segment index (immutable after `NewLine`, built once, shared across goroutines) offering `Within` / `WithinLE` / `DistToCapped` / `ProjectArcCapped` / `CrossSectionNear`. Since every built-in cap is ≤ the 32 m cell, each query's scan is exactly its cell's 3×3 block — precomputed per cell as a sorted, deduplicated list, so a query is one map lookup on a shared slice. Candidates run in ascending segment order, so min and tie selection resolve identically to the full scan.

**`math.Hypot` was ~20% of all CPU** (`4fcb820`) — its overflow-safe `archMin`/`archMax`/`IsInf` scaffolding, paid on every `Pt.Dist`. Scans now compare squared distances and compute the true distance once, on the winning segment — the identical rounded value the old code returned there. Threshold tests decide on the squared comparison outside a ±1e-9 relative band and fall back to the exact compare on the knife edge. `CrossSection` reads the cumulative arc from the cached `l.arc` (built by the identical addition chain) instead of re-accumulating a Hypot per segment per call.

**Parallelism where the work is genuinely per-index** (`07e8997`, `341ed7a`) — Match's per-sample emission scan, `Refine`'s cross-section sampling, and `GaussianArc` all compute each index from immutable inputs and write only that index. `geo.ParFor` strides them across workers above a 256-wide threshold. NYC went from 1.4 cores of useful work to ~3.

**`walk()` stops re-deriving its graph** (`471f33f`) — turn angles, crossover flags and level classes are pure functions of immutable graph geometry, so they're tabled at build time instead of costing two tangent extractions, an `Acos` and two string-map hashes per expansion. The per-call `best` map and label arena become epoch-stamped scratch.

**GTFS loads only what draws; the graph builds once** (`ea612d7`) — `LoadFiltered` drops foreign routes at the trips pass, so Chicago's 5.8M `stop_times` rows (~95% bus) fall to one map miss each and bus shapes never parse. Column indices resolve once per file, `csv.ReuseRecord` is on, and independent files parse concurrently into disjoint maps with fixed merge points. Match and Split now share one track-graph build — they already depended on the two builds being byte-identical for piece ids.

## Why NYC isn't sub-5s

The remaining ~8s is roughly 3.8s in the match window (serial Viterbi + GTFS load + graph build), ~2.3s in split (dominated by `GaussianArc`'s `math.Exp` core, which is irreducible while output must not move — the same exp calls must happen), and ~2s in order + fair.

Going below that means changing *what* is computed — fewer refinement passes, coarser sampling, a cheaper smoothing kernel — i.e. giving up the byte-identical contract. There is real headroom there if that trade is ever wanted; it just isn't this PR.

## Reviewing

The diff is 12 files, ~1150 insertions. Each commit is independently gate-verified, so bisecting by commit is meaningful. The two commits worth the closest reading are `210e599` (the bundling memo — its exactness argument is the subtlest thing here) and `e56e844`/`f2928cd` (the capped-query coverage proof).
