### PR TITLE
bundling patches its spatial index instead of rebuilding it each round

### DIFF
--- a/internal/geo/mutgrid.go
+++ b/internal/geo/mutgrid.go
@@ -1,0 +1,115 @@
+package geo
+
+import "math"
+
+// MutGrid is a uniform spatial hash over whole lines that supports removal
+// and insertion, addressed by caller-supplied stable keys instead of slice
+// positions. Grid rebuilds its whole index; a caller that mutates a few
+// lines per round would pay for every line every round.
+//
+// Membership semantics match Grid exactly — a key is visited when some
+// segment of its line lies within reach of the query point, tested with
+// the same segWithin predicate over the same cell radius, and visited at
+// most once per query. The VISIT ORDER differs from Grid's, so MutGrid is
+// only for callers that consume the visited set (or per-query counts),
+// never the order — Grid.Near's order is load-bearing for some callers.
+type MutGrid struct {
+	cell  float64
+	cells map[[2]int][]mref
+	lines map[int64]*Line
+	seen  map[int64]bool // query scratch; MutGrid is single-goroutine
+}
+
+// mref carries the line pointer so a query needs no map lookup per segment.
+type mref struct {
+	key int64
+	l   *Line
+	seg int
+}
+
+func NewMutGrid(cell float64) *MutGrid {
+	return &MutGrid{cell: cell, cells: map[[2]int][]mref{},
+		lines: map[int64]*Line{}, seen: map[int64]bool{}}
+}
+
+func (g *MutGrid) key(p Pt) [2]int {
+	return [2]int{int(math.Floor(p.X / g.cell)), int(math.Floor(p.Y / g.cell))}
+}
+
+// eachCell visits every cell the segment a→b touches, by endpoint bbox —
+// the same rasterization Grid uses, so both index a segment identically.
+func (g *MutGrid) eachCell(a, b Pt, fn func([2]int)) {
+	ka, kb := g.key(a), g.key(b)
+	x0, x1 := min(ka[0], kb[0]), max(ka[0], kb[0])
+	y0, y1 := min(ka[1], kb[1]), max(ka[1], kb[1])
+	for x := x0; x <= x1; x++ {
+		for y := y0; y <= y1; y++ {
+			fn([2]int{x, y})
+		}
+	}
+}
+
+// Add indexes a line under key. Adding a key that is already present
+// replaces it.
+func (g *MutGrid) Add(key int64, l *Line) {
+	if _, ok := g.lines[key]; ok {
+		g.Remove(key)
+	}
+	g.lines[key] = l
+	for si := 1; si < len(l.Pts); si++ {
+		a, b := l.Pts[si-1], l.Pts[si]
+		g.eachCell(a, b, func(c [2]int) {
+			g.cells[c] = append(g.cells[c], mref{key, l, si})
+		})
+	}
+}
+
+// Remove drops a key's line from the index.
+func (g *MutGrid) Remove(key int64) {
+	l, ok := g.lines[key]
+	if !ok {
+		return
+	}
+	delete(g.lines, key)
+	touched := map[[2]int]bool{}
+	for si := 1; si < len(l.Pts); si++ {
+		g.eachCell(l.Pts[si-1], l.Pts[si], func(c [2]int) { touched[c] = true })
+	}
+	for c := range touched {
+		refs := g.cells[c]
+		kept := refs[:0]
+		for _, r := range refs {
+			if r.key != key {
+				kept = append(kept, r)
+			}
+		}
+		if len(kept) == 0 {
+			delete(g.cells, c)
+		} else {
+			g.cells[c] = kept
+		}
+	}
+}
+
+// Near visits every distinct key with at least one segment within reach of
+// p. Visits are deduplicated; order is unspecified (see the type comment).
+// The dedup scratch is shared, so fn must not call Near again.
+func (g *MutGrid) Near(p Pt, reach float64, fn func(key int64)) {
+	r := int(math.Ceil(reach/g.cell)) + 1
+	k := g.key(p)
+	seen := g.seen
+	clear(seen)
+	for dx := -r; dx <= r; dx++ {
+		for dy := -r; dy <= r; dy++ {
+			for _, ref := range g.cells[[2]int{k[0] + dx, k[1] + dy}] {
+				if seen[ref.key] {
+					continue
+				}
+				if segWithin(p, ref.l.Pts[ref.seg-1], ref.l.Pts[ref.seg], reach) {
+					seen[ref.key] = true
+					fn(ref.key)
+				}
+			}
+		}
+	}
+}

--- a/internal/stages/bundle_edges.go
+++ b/internal/stages/bundle_edges.go
@@ -197,11 +197,14 @@ type bundleState struct {
 	samples map[int64][]geo.Pt // Resample(mergeDS)
 	cand    map[int64][]candEntry
 	neg     map[pairKey]struct{}
-	fresh   []int64      // ids minted by the last merge
-	dirty   [][]geo.Pt   // removed/new sample sets: neighborhoods to re-enumerate
-	arr     []*geo.Line  // per round: lines in current edge order
-	grid    *geo.Grid    // per round: spatial hash over arr
-	idIdx   map[int64]int
+	fresh   []int64    // ids minted by the last merge
+	gone    []int64    // ids retired by the last merge
+	dirty   [][]geo.Pt // removed/new sample sets: neighborhoods to re-enumerate
+	// grid indexes every current edge by content id. A merge touches two
+	// edges and mints a handful, so it is patched, not rebuilt — rebuilding
+	// cost Θ(rounds × E), and rounds grow with E.
+	grid  *geo.MutGrid
+	idIdx map[int64]int
 }
 
 type candEntry struct {
@@ -241,11 +244,22 @@ func (st *bundleState) beginRound(net *Network) {
 			st.samples[id] = l.Resample(mergeDS)
 		}
 	}
-	st.arr = st.arr[:0]
-	for _, id := range st.ids {
-		st.arr = append(st.arr, st.lines[id])
+	if st.grid == nil {
+		st.grid = geo.NewMutGrid(64)
+		for _, id := range st.ids {
+			st.grid.Add(id, st.lines[id])
+		}
+	} else {
+		// patch to the post-merge edge set — the same index a rebuild
+		// would produce, since surviving edges' geometry never changes
+		for _, id := range st.gone {
+			st.grid.Remove(id)
+		}
+		for _, id := range st.fresh {
+			st.grid.Add(id, st.lines[id])
+		}
+		st.gone = st.gone[:0]
 	}
-	st.grid = geo.NewGrid(st.arr, 64)
 	clear(st.idIdx)
 	for i, id := range st.ids {
 		st.idIdx[id] = i
@@ -263,14 +277,14 @@ func (st *bundleState) beginRound(net *Network) {
 	// reach 31 marks a superset of the affected edges, and
 	// over-invalidation merely recomputes identical lists.
 	if len(st.dirty) > 0 {
-		aff := map[int]bool{}
+		aff := map[int64]bool{}
 		for _, pts := range st.dirty {
 			for _, q := range pts {
-				st.grid.Near(q, 31, func(li int) { aff[li] = true })
+				st.grid.Near(q, 31, func(id int64) { aff[id] = true })
 			}
 		}
-		for li := range aff {
-			delete(st.cand, st.ids[li])
+		for id := range aff {
+			delete(st.cand, id)
 		}
 		st.dirty = st.dirty[:0]
 	}
@@ -284,7 +298,7 @@ func (st *bundleState) candFor(a int) []candEntry {
 	if c, ok := st.cand[id]; ok {
 		return c
 	}
-	counts := map[int]int{}
+	counts := map[int64]int{}
 	for _, q := range st.samples[id] {
 		// gap bridges DO merge into a real corridor they shadow — a
 		// bridged service running alongside ridden track is the same
@@ -292,15 +306,15 @@ func (st *bundleState) candFor(a int) []candEntry {
 		// gaps have no parallel corridor and are untouched
 		// candidate reach covers the banded-corridor width, not just
 		// the kiss range — the DeKalb bypass rides 10–25 m out
-		st.grid.Near(q, 25, func(b int) {
-			if b != a {
+		st.grid.Near(q, 25, func(b int64) {
+			if b != id {
 				counts[b]++
 			}
 		})
 	}
 	list := make([]candEntry, 0, len(counts))
 	for b, n := range counts {
-		list = append(list, candEntry{st.ids[b], n})
+		list = append(list, candEntry{b, n})
 	}
 	sort.Slice(list, func(i, j int) bool { return list[i].id < list[j].id })
 	st.cand[id] = list
@@ -825,6 +839,7 @@ func applyMerge(net *Network, st *bundleState, a, b int, a1, a2 float64, minSpan
 	// ones; the removed and added sample sets drive cand invalidation)
 	oldA, oldB := st.ids[a], st.ids[b]
 	st.dirty = append(st.dirty, st.samples[oldA], st.samples[oldB])
+	st.gone = append(st.gone, oldA, oldB)
 	var out []Edge
 	newIDs := make([]int64, 0, len(net.Edges)+len(newEdges)-1)
 	for ei, e := range net.Edges {


### PR DESCRIPTION
Follow-up to #1. Removes the quadratic term that timing all nine configured cities exposed. Output stays byte-identical.

## What the city sweep showed

Timing every city in `portolan.json` (Berlin and Tokyo can't chart — no `shapes.txt`) made it clear that **rail size is not the cost driver**. London has the most OSM ways (13k) and finishes in 7s; Paris has 8k ways and took 50–60s. Cost tracks the *network graph after splitting*.

The bundling loop applies exactly one merge per round, and `beginRound` rebuilt a `geo.Grid` over **every** edge each round — Θ(rounds × E), with rounds themselves proportional to E:

| city | edges | merge rounds | E × rounds | split | ms per (E × round) |
|---|---|---|---|---|---|
| Chicago | 33 | 16 | 528 | 1.8s | 3.4 |
| London | 198 | 57 | 11,286 | 3.8s | 0.34 |
| NYC | 164 | 91 | 14,924 | 3.0s | 0.20 |
| Paris | 560 | 255 | 142,800 | 28.3s | **0.20** |

NYC and Paris land on the same constant to two digits across a 10× span. A CPU profile confirmed the mechanism directly: `beginRound` → `NewGrid` was 9.3s of the merge loop's 14.2s on Paris.

## The change

`geo.MutGrid` indexes whole lines under caller-supplied stable keys and supports `Remove`/`Add`, so a merge patches two removals and a handful of insertions instead of reindexing the network.

**Why the patched index equals the rebuild it replaces:** a merge removes exactly two edges and appends the cut parts plus the merged corridor; it never alters a surviving edge's geometry (only `From`/`To` node ids, which the index doesn't use). So removing the two retired ids and adding the fresh ones yields exactly the index a from-scratch rebuild over the current edge set would produce.

**Why the different visit order is safe.** `MutGrid.Near` tests the same `segWithin` predicate over the same cell radius and dedups per query, so the visited *set* and the per-sample *counts* are identical — but it iterates in a different order than `Grid.Near`. Bundling never consumes that order: `candFor` accumulates counts into a map and sorts the result by id, and the invalidation pass builds a set. `Grid` keeps its ordered `Near` untouched, because that order **is** load-bearing elsewhere — FAIR's `trackCurveBetween` breaks connector-score ties by first visit, which is why #1 had to leave `Grid.Near`'s scan radius alone.

Refs carry their line pointer and the dedup scratch is reused across queries, so a lookup costs no map indirection per segment.

## Verification

Same gate as #1: SHA-256 of all five emitted GeoJSON files per city against the frozen pre-optimization baseline.

- **NYC and Chicago byte-identical** (gate), and **Paris byte-identical** too (checked separately, since it is the city this actually changes).
- `go test ./...` green.
- NYC reproduces its hash 3/3 — determinism holds.
- Verified on this exact branch (cherry-picked onto current `dev`), not just on the branch it was authored on.

## Effect

| city | edges | wall before | wall after | CPU before | CPU after |
|---|---|---|---|---|---|
| Charlotte | 2 | 0.45s | 0.40s | 1.23 | 1.22 |
| Atlanta | 8 | 1.52s | 1.42s | 4.00 | 3.80 |
| LA | 14 | 3.56s | 3.25s | 15.0 | 13.7 |
| Chicago | 23 | 5.49s | 5.6s | 13.7 | 14.6 |
| London | 165 | 6.89s | 7.05s | 29.3 | 27.5 |
| NYC | 114 | 9.51s | 8.13s | 26.8 | 24.9 |
| Paris | 418 | 50–60s | **43–46s** | 162 | **152** |

Paris SPLIT alone: **28.3s → 19.5s**. Small cities are flat, as expected — the removed term is quadratic, so it only surfaces where E is large.

*Measurement caveat:* the host was under load average 17–38 during this batch, so wall times carry roughly ±20% noise. The CPU column and an interleaved old/new A/B on Paris (three rounds, alternating binaries under identical load) are the trustworthy comparisons.

## What this does not fix

- `mergeOnePair` still scans every edge and its candidate list each round, so bookkeeping remains Θ(E²·c) — with a much smaller constant now that it is memo lookups rather than reindexing.
- **ORDER is a latent factorial cliff.** `permute` enumerates all *k!* orderings of an edge's colors inside a 50-pass climb. Measured max colors on any one edge: Charlotte 1, Atlanta 2, LA 2, London 3, NYC 4, Chicago 6, Paris 6. 6! = 720 is survivable; 8 colors would mean 40,320 permutations per edge per pass, and 10 means 3.6M. Fixing it (branch-and-bound, or adjacent-transposition search above some k) **would change output**, so it needs its own gate discussion rather than a quiet fix.
