### PR TITLE
console: light mode — chrome, basemap and labels flip together

### DIFF
--- a/internal/stages/terminal_cuts.go
+++ b/internal/stages/terminal_cuts.go
@@ -110,7 +110,6 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 		si      int
 		covers  map[int][]pathCover
 		trusted []bool
-		changed bool
 	}
 	var prep []prepared
 	for si := range segs {
@@ -125,7 +124,6 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 		covers := make(map[int][]pathCover, len(s.Routes))
 		trusted := make([]bool, len(s.Routes))
 		var cuts []float64
-		changed := false
 		for ri, rid := range s.Routes {
 			ok := true
 			var cvs []pathCover
@@ -161,12 +159,42 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 						}
 					}
 				}
+				// the THROUGH-TAIL case: the path runs the whole segment
+				// because MATCH appends terminal pieces whole, but the
+				// pattern's last STOP sits mid-segment — the H's shape
+				// ends AT Rockaway Blvd while its matched path runs the
+				// full piece to the 80 St crossover. Coverage ends at
+				// the stop; the relay tail beyond gets nothing.
+				if terminal < 0 && terms != nil && cv.a <= 1 && cv.b >= L-1 {
+					for _, stop := range terms[pi] {
+						if stop == (geo.Pt{}) {
+							continue
+						}
+						sa, sd := s.Line.ProjectArc(stop)
+						if sd > 80 || sa <= tcMarginM || sa >= L-tcMarginM {
+							continue
+						}
+						// which side is the tail? The side holding the
+						// path's nearer TIP, close to the segment.
+						pp := pa.Line.Pts
+						for _, tip := range []geo.Pt{pp[0], pp[len(pp)-1]} {
+							ta, td := s.Line.ProjectArc(tip)
+							if td > tcEndDistM {
+								continue
+							}
+							if ta > sa && L-ta < tcMarginM {
+								cv.b = sa // tail on the high side
+								terminal = sa
+							} else if ta < sa && ta < tcMarginM {
+								cv.a = sa // tail on the low side
+								terminal = sa
+							}
+						}
+					}
+				}
 				cvs = append(cvs, cv)
 				if terminal >= 0 && terminal > tcMarginM && terminal < L-tcMarginM {
 					cuts = append(cuts, terminal)
-				}
-				if cv.a > 1 || cv.b < L-1 {
-					changed = true // partial coverage — acts may differ per piece
 				}
 			}
 			if ok && len(cvs) > 0 {
@@ -175,7 +203,7 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 			}
 		}
 		groupCuts[segSig[si]] = append(groupCuts[segSig[si]], cuts...)
-		prep = append(prep, prepared{si: si, covers: covers, trusted: trusted, changed: changed})
+		prep = append(prep, prepared{si: si, covers: covers, trusted: trusted})
 	}
 
 	// deduped cut arcs per geometry group
@@ -209,7 +237,7 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 			}
 		}
 		pr := prepBySeg[si]
-		if len(arcs) == 0 && (pr == nil || !pr.changed) {
+		if len(arcs) == 0 && pr == nil {
 			out = append(out, *s)
 			continue
 		}

--- a/web/index.html
+++ b/web/index.html
@@ -1,10 +1,23 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark light" />
     <title>Portolan</title>
+    <script>
+      // Theme BEFORE first paint. lib/theme.ts owns this decision, but it
+      // runs after the module graph loads and Vue mounts — settling it
+      // there alone flashes the wrong shell on every load. Same key, same
+      // rule (query light so an unknown preference lands on dark); change
+      // one and change the other.
+      ;(function () {
+        var t = localStorage.getItem('portolan.theme')
+        var dark = t === 'dark' || (t !== 'light' && !matchMedia('(prefers-color-scheme: light)').matches)
+        document.documentElement.classList.toggle('dark', dark)
+        document.documentElement.style.colorScheme = dark ? 'dark' : 'light'
+      })()
+    </script>
     <link rel="stylesheet" href="/vendor/maplibre-gl.css" />
     <script src="/vendor/maplibre-gl.js"></script>
   </head>

--- a/web/scripts/dynamic-check.mjs
+++ b/web/scripts/dynamic-check.mjs
@@ -433,6 +433,30 @@ if (!fs.existsSync(unionPath) || !fs.existsSync(scenPath)) {
       night > -73.94, `westmost M lon ${night.toFixed(4)}`)
     check('weekend M ends at Delancey/Essex (not the Chrystie fork)',
       wknd > -73.9895 && wknd < -73.985, `westmost M lon ${wknd.toFixed(4)}`)
+
+    // the H's MATCH path overruns its Rockaway Blvd terminal by 1.3 km
+    // of relay trackage to the 80 St crossover; that tail must carry NO
+    // hours at all — and gap-mask 24/7 lies must not survive the acts
+    // recompute (the extension shuttle runs 8-21 only)
+    const hFeats = JSON.parse(fs.readFileSync(unionP, 'utf8')).features.filter(
+      (f) => f.properties.band_min === 15 && f.properties.kind !== 'transition' &&
+        String(f.properties.routes).split(',').includes('H'),
+    )
+    let tailLit = 0
+    let east321 = false
+    for (const f of hFeats) {
+      const rts = String(f.properties.routes).split(',')
+      const a = String(f.properties.acts ?? '').split(';')[rts.indexOf('H')]
+      if (!a || a.length !== 42) continue
+      const anyHour = [...Array(7)].some((_, d) => parseInt(a.slice(d * 6, d * 6 + 6), 16) !== 0)
+      const lons = f.geometry.coordinates.map((c) => c[0])
+      const lats = f.geometry.coordinates.map((c) => c[1])
+      if (Math.min(...lats) > 40.66 && Math.min(...lons) < -73.845 && anyHour) tailLit++
+      if (Math.min(...lats) > 40.66 && Math.min(...lons) > -73.845 && Math.min(...lons) < -73.83 &&
+        mAct(a, 5, 14)) east321 = true
+    }
+    check('the H relay tail west of Rockaway Blvd is never lit', tailLit === 0, `${tailLit} lit`)
+    check('the H extension IS lit east of Rockaway Blvd on Sat 14:00', east321)
   }
 }
 

--- a/web/src/components/AppSidebar.vue
+++ b/web/src/components/AppSidebar.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-import { Map, MapPin, Hammer, Clock, Palette, Crosshair, Compass, PenTool, SlidersHorizontal } from 'lucide-vue-next'
+import { Map, MapPin, Hammer, Clock, Palette, Crosshair, Compass, PenTool, SlidersHorizontal, Sun, Moon, Monitor } from 'lucide-vue-next'
 import Badge from './ui/Badge.vue'
 import Select from './ui/Select.vue'
 import Spinner from './ui/Spinner.vue'
 import { cities, feed, run } from '@/lib/store'
+import { theme, THEMES, type Theme } from '@/lib/theme'
 
 const route = useRoute()
 const nav = [
@@ -22,6 +23,8 @@ const config = [
 ]
 const isActive = (to: string) => route.path === to || route.path.startsWith(`${to}/`)
 const options = computed(() => cities.value.map((c) => ({ value: c.id, label: c.name || c.id })))
+
+const themeIcon: Record<Theme, any> = { light: Sun, system: Monitor, dark: Moon }
 </script>
 
 <template>
@@ -88,6 +91,28 @@ const options = computed(() => cities.value.map((c) => ({ value: c.id, label: c.
       >
         <Compass class="size-4" /> Old workbench
       </a>
+
+      <!-- Three states, not a switch: 'system' is a real choice and the
+           default, and a two-way toggle has nowhere to put it. -->
+      <div class="mt-2 flex items-center gap-1 rounded-lg bg-muted/60 p-1">
+        <button
+          v-for="t in THEMES"
+          :key="t"
+          type="button"
+          :title="t === 'system' ? 'Follow system appearance' : t[0].toUpperCase() + t.slice(1) + ' theme'"
+          :aria-pressed="theme === t"
+          :class="[
+            'flex flex-1 items-center justify-center rounded-md py-1.5 transition-colors',
+            theme === t
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground',
+          ]"
+          @click="theme = t"
+        >
+          <component :is="themeIcon[t]" class="size-4" />
+          <span class="sr-only">{{ t }}</span>
+        </button>
+      </div>
     </div>
   </aside>
 </template>

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -1,0 +1,59 @@
+// Light/dark, module-singleton like lib/store.ts. Three states, not two:
+// 'system' follows the OS and is the default, so a machine in light mode
+// gets a light console without anyone touching a switch — while an
+// explicit pick still sticks across reloads.
+//
+// The class this drives (`.dark` on <html>) is ALSO set by an inline
+// script in index.html. That duplication is deliberate: Vue mounts after
+// first paint, so deciding the theme here alone flashes the wrong shell
+// on every load. Keep the two in step.
+import { ref, computed, watch } from 'vue'
+
+export type Theme = 'light' | 'dark' | 'system'
+
+const KEY = 'portolan.theme'
+// Query LIGHT, not dark: an OS that reports neither (or a browser with no
+// matchMedia support for the query) then falls through to dark, which is
+// the console's historical look.
+const media = window.matchMedia('(prefers-color-scheme: light)')
+
+const stored = localStorage.getItem(KEY)
+export const theme = ref<Theme>(stored === 'light' || stored === 'dark' ? stored : 'system')
+
+const systemLight = ref(media.matches)
+media.addEventListener('change', (e) => (systemLight.value = e.matches))
+
+/** What is actually painted right now. Everything theme-aware — including
+ *  the map, which has no CSS to inherit — watches this, not `theme`. */
+export const isDark = computed(() => (theme.value === 'system' ? !systemLight.value : theme.value === 'dark'))
+
+watch(
+  isDark,
+  (dark) => {
+    const root = document.documentElement
+    root.classList.toggle('dark', dark)
+    // form controls (the datetime picker, scrollbars, native menus) read
+    // this, not the class
+    root.style.colorScheme = dark ? 'dark' : 'light'
+  },
+  { immediate: true },
+)
+
+// 'system' is the absence of a preference, so it is stored as the absence
+// of a key — a browser whose OS setting later changes then follows it.
+watch(theme, (v) => (v === 'system' ? localStorage.removeItem(KEY) : localStorage.setItem(KEY, v)))
+
+export const THEMES: Theme[] = ['light', 'system', 'dark']
+
+// WebGL inherits no CSS, so every map picks its basemap by hand. The URL
+// pair is shared; the raster OPACITY is not, because it is what sets how
+// far the city recedes and each map wants a different amount (the sketch
+// editor traces against a fainter one). It has to differ by theme too:
+// these tiles composite straight onto the page — the style carries no
+// background layer — so a value that mutes the dark tiles over near-black
+// washes the light tiles out to nothing over white.
+export const BASEMAP_TILES = {
+  dark: 'https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png',
+  light: 'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png',
+}
+export const basemapTiles = () => (isDark.value ? BASEMAP_TILES.dark : BASEMAP_TILES.light)

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -124,8 +124,7 @@
   background-size: 22px 22px;
 }
 
-/* MapLibre's own stylesheet ships light chrome; the console is dark by
-   default and the map fills its pane. */
+/* MapLibre's own stylesheet ships light chrome; the map fills its pane. */
 .maplibregl-map {
   font: inherit;
 }

--- a/web/src/views/MapView.vue
+++ b/web/src/views/MapView.vue
@@ -8,6 +8,7 @@ import Spinner from '@/components/ui/Spinner.vue'
 import { api, fetchBuild, type Scenario, type StyleSet } from '@/lib/api'
 import { applyDynamic, activePredicate, activeRouteIdx, markerIconAt, maskActive, stationVisible, type BundleRow } from '@/lib/dynamic'
 import { feed, currentCity, run } from '@/lib/store'
+import { basemapTiles, isDark } from '@/lib/theme'
 import { toast } from '@/lib/toast'
 
 // MapLibre comes from the FORK the server exposes at /vendor — it carries
@@ -40,6 +41,45 @@ const BANDS = [
   { min: 13, max: 14, key: 13 },
   { min: 0, max: 13, key: 0 },
 ]
+
+// ── theme (lib/theme.ts) ───────────────────────────────────────────────
+// WebGL inherits no CSS: the basemap and every label colour are switched
+// by hand when the theme flips.
+// CARTO's light tiles are already pale enough to sit under the ribbons at
+// full strength; dimming them the way the dark tiles need washes the
+// street grid out entirely.
+const rasterOpacity = () => (isDark.value ? 0.55 : 1)
+// Station names are drawn OVER coloured ribbons in both themes, so the
+// halo does the separating work and has to invert with the basemap; the
+// text just needs enough contrast against its own halo.
+const LABEL = {
+  dark: { color: '#e8e8ee', halo: 'rgba(12,12,16,0.9)' },
+  light: { color: '#1b1b22', halo: 'rgba(255,255,255,0.92)' },
+}
+const labelPaint = () => {
+  const t = isDark.value ? LABEL.dark : LABEL.light
+  return { 'text-color': t.color, 'text-halo-color': t.halo, 'text-halo-width': 1.4 }
+}
+const LABEL_LAYERS = ['station-labels', 'station-labels-hi']
+
+// The marker images (dots, pills, bullets) are NOT re-themed: every one
+// of them sits on top of a route's own colour, so they read the same
+// against either basemap — and their ids are content-addressed, so a
+// theme-dependent fill would need every cached image evicted.
+watch(isDark, () => {
+  if (!map) return
+  map.getSource('osm')?.setTiles([basemapTiles()])
+  map.setPaintProperty('osm', 'raster-opacity', rasterOpacity())
+  const p = labelPaint()
+  for (const id of LABEL_LAYERS) {
+    if (!map.getLayer(id)) continue
+    for (const [k, v] of Object.entries(p)) map.setPaintProperty(id, k, v)
+  }
+  if (map.getLayer('dbg-nodes')) map.setPaintProperty('dbg-nodes', 'circle-stroke-color', nodeStroke())
+})
+// debug node halo: the one debug layer whose colour is a contrast choice
+// rather than an identity
+const nodeStroke = () => (isDark.value ? '#fff' : '#1b1b22')
 
 // Offsets live in DIFFERENT properties depending on the segment kind, and
 // getting this wrong is invisible in the data and glaring on the map: a
@@ -716,11 +756,7 @@ function addLayers() {
       'icon-offset': bulletOffset,
       'icon-optional': true,
     },
-    paint: {
-      'text-color': '#e8e8ee',
-      'text-halo-color': 'rgba(12,12,16,0.9)',
-      'text-halo-width': 1.4,
-    },
+    paint: labelPaint(),
   })
   // per-corridor labels for complexes at z15+: this corridor's name and
   // ITS bullets (Fulton St splits into A·C / J·Z / 2·3 / 4·5 labels the
@@ -741,13 +777,9 @@ function addLayers() {
       'icon-offset': bulletOffset,
       'icon-optional': true,
     },
-    paint: {
-      'text-color': '#e8e8ee',
-      'text-halo-color': 'rgba(12,12,16,0.9)',
-      'text-halo-width': 1.4,
-    },
+    paint: labelPaint(),
   })
-  for (const id of ['station-markers', 'station-labels', 'station-labels-hi']) {
+  for (const id of ['station-markers', ...LABEL_LAYERS]) {
     map.on('click', id, (e: any) => {
       inspect.value = e.features?.[0]?.properties ?? null
     })
@@ -774,7 +806,7 @@ function addLayers() {
     id: 'dbg-nodes', type: 'circle', source: 'nodes',
     paint: {
       'circle-radius': ['+', 2, ['get', 'degree']], 'circle-color': '#e33',
-      'circle-opacity': 0.8, 'circle-stroke-color': '#fff', 'circle-stroke-width': 1,
+      'circle-opacity': 0.8, 'circle-stroke-color': nodeStroke(), 'circle-stroke-width': 1,
     },
     layout: { visibility: 'none' },
   })
@@ -863,12 +895,12 @@ onMounted(async () => {
       sources: {
         osm: {
           type: 'raster',
-          tiles: ['https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png'],
+          tiles: [basemapTiles()],
           tileSize: 256,
           attribution: '© OpenStreetMap © CARTO',
         },
       },
-      layers: [{ id: 'osm', type: 'raster', source: 'osm', paint: { 'raster-opacity': 0.55 } }],
+      layers: [{ id: 'osm', type: 'raster', source: 'osm', paint: { 'raster-opacity': rasterOpacity() } }],
     },
   })
   map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'bottom-right')
@@ -955,7 +987,8 @@ watch(feed, async () => {
         <input
           v-model="when"
           type="datetime-local"
-          class="h-8 rounded-md border border-input bg-transparent px-2 text-sm [color-scheme:dark]"
+          class="h-8 rounded-md border border-input bg-transparent px-2 text-sm"
+          :class="isDark ? '[color-scheme:dark]' : '[color-scheme:light]'"
         />
         <Button variant="ghost" size="sm" title="Jump to the current time" @click="when = localNow()">now</Button>
 

--- a/web/src/views/SketchView.vue
+++ b/web/src/views/SketchView.vue
@@ -9,6 +9,7 @@ import Input from '@/components/ui/Input.vue'
 import Switch from '@/components/ui/Switch.vue'
 import Spinner from '@/components/ui/Spinner.vue'
 import { feed, currentCity } from '@/lib/store'
+import { basemapTiles, isDark } from '@/lib/theme'
 import { toast } from '@/lib/toast'
 import {
   History, bake, bakeAll, deleteAnchor, displayColor, handlesOf, insertAnchor, isCorner,
@@ -577,6 +578,16 @@ function fitCity() {
   if (map && b?.length === 4) map.fitBounds([[b[0], b[1]], [b[2], b[3]]], { padding: 40, duration: 0 })
 }
 
+// The basemap is only ever a tracing underlay here, so it sits fainter
+// than the map view's — but the light tiles still need more of it than
+// the dark ones to be legible at all (lib/theme.ts).
+const rasterOpacity = () => (isDark.value ? 0.5 : 0.9)
+watch(isDark, () => {
+  if (!map) return
+  map.getSource('osm')?.setTiles([basemapTiles()])
+  map.setPaintProperty('osm', 'raster-opacity', rasterOpacity())
+})
+
 onMounted(() => {
   if (typeof maplibregl === 'undefined') {
     toast({ title: 'MapLibre not loaded', variant: 'error' })
@@ -593,12 +604,12 @@ onMounted(() => {
       sources: {
         osm: {
           type: 'raster',
-          tiles: ['https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png'],
+          tiles: [basemapTiles()],
           tileSize: 256,
           attribution: '© OpenStreetMap © CARTO',
         },
       },
-      layers: [{ id: 'osm', type: 'raster', source: 'osm', paint: { 'raster-opacity': 0.5 } }],
+      layers: [{ id: 'osm', type: 'raster', source: 'osm', paint: { 'raster-opacity': rasterOpacity() } }],
     },
   })
   ro = new ResizeObserver(() => map?.resize())


### PR DESCRIPTION
The console shipped dark-only, with `.dark` nailed to `<html>`. The light tokens were already sitting in `:root` unused, so the CSS side is a switch — the map is the actual work, because WebGL inherits no CSS and every colour there is a literal.

### Theme state

`web/src/lib/theme.ts` holds it — three values, not two. `system` is the default and is stored as the **absence** of the key, so a machine whose OS preference changes later follows it instead of being pinned by a value written once. The media query asks for *light*, so a browser that reports neither falls through to dark, the console's historical look.

`index.html` re-decides the same thing in an inline pre-paint script: Vue mounts after first paint, and settling it only in the module flashed the wrong shell on every load. Both sides are commented as one rule with two homes.

A sun/monitor/moon segmented control sits in the sidebar footer.

### Map

Re-themes in place rather than through `setStyle`: `setTiles` on the raster source plus `setPaintProperty` on the two label layers, so the ribbon layers, the loaded bands and the marker image cache all survive a flip. Station names invert to `#1b1b22` on a white halo — the halo does the separating work in both themes, since names are drawn over coloured ribbons either way.

Raster opacity is per-theme **and** per-view, not one constant. These tiles composite straight onto the page (the style carries no background layer), so `0.55` — which mutes CARTO's dark tiles over near-black — washes the light tiles out to nothing over white. Light runs at full strength on the map view, `0.9` in the sketch editor, where the basemap is only ever a tracing underlay.

Marker dots, bundle pills and route bullets are deliberately **not** re-themed: each sits on top of a route's own colour and reads the same against either basemap, and their ids are content-addressed, so a theme-dependent fill would need the whole image cache evicted on every flip.

### Verification

Checked in the browser both ways at z14 midtown: light basemap with dark labels and bullets, flipped live to dark tiles / `#e8e8ee` labels / `0.55` with no reload and no layer teardown. `typecheck`, `check` and `build` green.

---

Note: this branch also carries `2e7cf89` (*terminal cuts: MATCH relay tails go dark; acts recompute always runs*), which is unrelated to the light-mode work.