### PR TITLE
console: adaptive mobile layout, collapsed layer picker

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { Menu, Compass } from 'lucide-vue-next'
 import AppSidebar from './components/AppSidebar.vue'
 import Toaster from './components/ui/Toaster.vue'
 import { refreshFeeds, startRunPoll, stopRunPoll } from './lib/store'
@@ -9,12 +11,47 @@ onMounted(() => {
   startRunPoll()
 })
 onUnmounted(stopRunPoll)
+
+// On a phone the sidebar is a drawer; picking a destination is what closes
+// it, so navigation itself dismisses — no close button to hunt for.
+const sidebarOpen = ref(false)
+const route = useRoute()
+watch(() => route.fullPath, () => (sidebarOpen.value = false))
 </script>
 
 <template>
-  <div class="flex h-screen overflow-hidden">
-    <AppSidebar />
-    <main class="flex-1 overflow-y-auto app-grid-bg"><RouterView /></main>
+  <!-- dvh, not vh: mobile browser chrome overlaps 100vh and the bottom of
+       the map (and every bottom-anchored overlay) ends up under the URL bar -->
+  <div class="flex h-dvh flex-col overflow-hidden md:flex-row">
+    <header class="flex shrink-0 items-center gap-3 border-b border-border bg-card/40 px-4 py-2.5 md:hidden">
+      <button
+        type="button"
+        class="flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+        aria-label="Open navigation"
+        @click="sidebarOpen = true"
+      >
+        <Menu class="size-5" />
+      </button>
+      <div class="flex items-center gap-2">
+        <div class="flex size-7 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+          <Compass class="size-4" />
+        </div>
+        <span class="text-sm font-semibold">Portolan</span>
+      </div>
+    </header>
+
+    <div
+      v-if="sidebarOpen"
+      class="fixed inset-0 z-40 bg-black/50 md:hidden"
+      @click="sidebarOpen = false"
+    />
+    <AppSidebar
+      :class="[
+        'max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-50 max-md:bg-card max-md:shadow-xl max-md:transition-transform max-md:duration-200',
+        sidebarOpen ? 'max-md:translate-x-0' : 'max-md:-translate-x-full',
+      ]"
+    />
+    <main class="min-h-0 flex-1 overflow-y-auto app-grid-bg"><RouterView /></main>
   </div>
   <Toaster />
 </template>

--- a/web/src/components/GlobalNotice.vue
+++ b/web/src/components/GlobalNotice.vue
@@ -10,7 +10,7 @@ defineProps<{ title: string }>()
 </script>
 
 <template>
-  <div class="p-8">
+  <div class="p-4 sm:p-8">
     <div class="mx-auto max-w-2xl rounded-xl border border-dashed border-border py-16 text-center">
       <div class="mx-auto flex size-12 items-center justify-center rounded-xl bg-muted text-muted-foreground">
         <Globe class="size-6" />

--- a/web/src/components/PageHeader.vue
+++ b/web/src/components/PageHeader.vue
@@ -3,7 +3,7 @@ defineProps<{ title: string; subtitle?: string }>()
 </script>
 
 <template>
-  <header class="sticky top-0 z-20 border-b border-border bg-background/80 px-8 py-5 backdrop-blur">
+  <header class="sticky top-0 z-20 border-b border-border bg-background/80 px-4 py-4 backdrop-blur sm:px-8 sm:py-5">
     <div class="flex items-center justify-between gap-4">
       <div class="min-w-0">
         <h1 class="text-xl font-semibold tracking-tight">{{ title }}</h1>

--- a/web/src/components/ui/Dialog.vue
+++ b/web/src/components/ui/Dialog.vue
@@ -18,7 +18,7 @@ defineEmits<{ (e: 'update:open', v: boolean): void }>()
       />
       <DialogContent
         :class="cn(
-          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-card p-6 shadow-lg rounded-xl',
+          'fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-card p-4 shadow-lg rounded-xl sm:p-6',
           'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
           props.class)"
       >

--- a/web/src/views/AreasView.vue
+++ b/web/src/views/AreasView.vue
@@ -86,7 +86,7 @@ async function remove(a: Area) {
     </template>
   </PageHeader>
 
-  <div class="space-y-4 p-8">
+  <div class="space-y-4 p-4 sm:p-8">
     <Input v-model="query" placeholder="Search areas" class="max-w-sm" />
 
     <div v-if="loading" class="flex justify-center py-16"><Spinner class="size-6" /></div>

--- a/web/src/views/BuildView.vue
+++ b/web/src/views/BuildView.vue
@@ -116,7 +116,7 @@ const missingInputs = computed(() => {
   </PageHeader>
 
   <GlobalNotice v-if="isGlobal" title="Build" />
-  <div v-else class="space-y-6 p-8">
+  <div v-else class="space-y-6 p-4 sm:p-8">
     <div v-if="missingInputs.length" class="flex gap-2 rounded-lg border border-[var(--warning)]/40 bg-[var(--warning)]/10 p-3 text-xs text-[var(--warning)]">
       <AlertTriangle class="mt-0.5 size-3.5 shrink-0" />
       <span>Missing inputs — the build will fail: <span class="font-mono">{{ missingInputs.join(', ') }}</span></span>

--- a/web/src/views/FeedsView.vue
+++ b/web/src/views/FeedsView.vue
@@ -127,7 +127,7 @@ const mb = (n?: number) => (n ? `${(n / 1e6).toFixed(1)} MB` : '')
     </template>
   </PageHeader>
 
-  <div class="p-8">
+  <div class="p-4 sm:p-8">
     <div v-if="feedsLoading && !feeds.length" class="flex justify-center py-16"><Spinner class="size-6" /></div>
 
     <div v-else-if="!feeds.length" class="rounded-xl border border-dashed border-border py-16 text-center">
@@ -198,7 +198,7 @@ const mb = (n?: number) => (n ? `${(n / 1e6).toFixed(1)} MB` : '')
     @update:open="(v) => !v && (editing = null)"
   >
     <div v-if="editing" class="flex max-h-[70vh] flex-col gap-4 overflow-y-auto pr-1">
-      <div class="grid grid-cols-2 gap-4">
+      <div class="grid gap-4 sm:grid-cols-2">
         <div class="flex flex-col gap-1.5">
           <Label for="cid">Feed id</Label>
           <Input id="cid" v-model="editing.id" :disabled="!isNew" placeholder="bvg" @blur="autofill" />
@@ -218,7 +218,7 @@ const mb = (n?: number) => (n ? `${(n / 1e6).toFixed(1)} MB` : '')
         </p>
       </div>
 
-      <div class="grid grid-cols-2 gap-4">
+      <div class="grid gap-4 sm:grid-cols-2">
         <div class="flex flex-col gap-1.5">
           <Label for="crail">Rail extract</Label>
           <Input id="crail" v-model="editing.rail" placeholder="build/bvg-rail.geojson" />
@@ -239,7 +239,7 @@ const mb = (n?: number) => (n ? `${(n / 1e6).toFixed(1)} MB` : '')
         </p>
       </div>
 
-      <div class="grid grid-cols-2 gap-4">
+      <div class="grid gap-4 sm:grid-cols-2">
         <div class="flex flex-col gap-1.5">
           <Label for="cout">Build output</Label>
           <Input id="cout" v-model="editing.out" placeholder="build/bvg.geojson" />

--- a/web/src/views/MapView.vue
+++ b/web/src/views/MapView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, watch, computed } from 'vue'
-import { Layers, Crosshair, RefreshCw, Clock, Copy, Check } from 'lucide-vue-next'
+import { Layers, Crosshair, RefreshCw, Clock, Copy, Check, X } from 'lucide-vue-next'
 import Button from '@/components/ui/Button.vue'
 import Badge from '@/components/ui/Badge.vue'
 import Switch from '@/components/ui/Switch.vue'
@@ -164,6 +164,11 @@ const KINDS: [string, any][] = [
 // and detaches by restoring exactly this, so recombination is lossless
 const structuralFilter = new Map<string, any>()
 const debug = ref({ paths: false, trackcenter: false, nodes: false, rail: false })
+
+// The layer picker starts folded to a single button: expanded it covers a
+// third of a phone screen, and the toggles are an occasional tool, not
+// something worth paying map area for on every visit.
+const layersOpen = ref(false)
 
 // per-class visibility. Stored as the DISABLED set so the default —
 // everything on — is an empty set and new classes appearing in a build
@@ -2026,9 +2031,9 @@ watch(feed, async () => {
          scenario dropdown is gone: a timestamp IS the scenario selection
          now (dynamic rendering), and the prebuilt-scenario QA controls
          live on the Service page. -->
-    <div class="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center p-4">
+    <div class="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center p-2 sm:p-4">
       <div class="pointer-events-auto flex max-w-full flex-wrap items-center gap-1 rounded-xl border border-border bg-card/90 px-2 py-1.5 shadow-sm backdrop-blur">
-        <span class="px-2 text-sm font-medium">{{ isGlobal ? 'Global' : currentFeed?.name || 'No feed' }}</span>
+        <span class="max-w-[40vw] truncate px-2 text-sm font-medium sm:max-w-none">{{ isGlobal ? 'Global' : currentFeed?.name || 'No feed' }}</span>
         <Badge v-if="loading" variant="info"><Spinner class="size-3" /></Badge>
         <Button variant="ghost" size="icon" title="Reload" @click="reload"><RefreshCw class="size-4" /></Button>
         <Button variant="ghost" size="icon" title="Fit to feed" @click="fitFeed"><Crosshair class="size-4" /></Button>
@@ -2074,10 +2079,27 @@ watch(feed, async () => {
       </div>
     </div>
 
-    <div class="pointer-events-auto absolute bottom-4 left-4 z-10 w-56 rounded-xl border border-border bg-card/90 p-3 shadow-sm backdrop-blur">
-      <div class="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+    <!-- collapsed until asked for: one button holds the corner, the full
+         panel replaces it in place and folds back from its header -->
+    <button
+      v-if="!layersOpen"
+      class="pointer-events-auto absolute bottom-4 left-4 z-10 flex items-center gap-2 rounded-xl border border-border bg-card/90 px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-accent hover:text-foreground"
+      title="Basemap, class and debug toggles"
+      @click="layersOpen = true"
+    >
+      <Layers class="size-3.5" /> Layers
+    </button>
+    <div
+      v-else
+      class="pointer-events-auto absolute bottom-4 left-4 z-10 max-h-[calc(100%-6rem)] w-56 overflow-y-auto rounded-xl border border-border bg-card/90 p-3 shadow-sm backdrop-blur"
+    >
+      <button
+        class="mb-2 flex w-full items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground"
+        @click="layersOpen = false"
+      >
         <Layers class="size-3.5" /> Layers
-      </div>
+        <X class="ml-auto size-3.5" />
+      </button>
       <!-- the basemap is what the drawn network is read against, so it
            sits above the class toggles: blank to judge geometry alone,
            OpenRailwayMap to check a ribbon against the real alignment -->
@@ -2112,7 +2134,7 @@ watch(feed, async () => {
 
     <button
       class="pointer-events-auto absolute z-10 flex items-center gap-2 rounded-lg border border-border bg-card/90 px-2.5 py-1.5 font-mono text-xs shadow-sm backdrop-blur transition-colors hover:bg-accent"
-      :class="inspect ? 'bottom-4 right-[19.5rem]' : 'bottom-4 right-4'"
+      :class="inspect ? 'bottom-4 right-4 max-sm:hidden sm:right-[19.5rem]' : 'bottom-4 right-4'"
       :title="`Copy ${viewText} to the clipboard`"
       @click="copyView"
     >
@@ -2130,7 +2152,7 @@ watch(feed, async () => {
 
     <div
       v-if="inspect"
-      class="pointer-events-auto absolute bottom-4 right-4 z-10 w-72 rounded-xl border border-border bg-card/95 p-3 shadow-lg backdrop-blur"
+      class="pointer-events-auto absolute bottom-4 right-4 z-10 max-h-[calc(100%-6rem)] w-72 overflow-y-auto rounded-xl border border-border bg-card/95 p-3 shadow-lg backdrop-blur max-sm:left-4 max-sm:w-auto"
     >
       <div class="mb-2 flex items-center justify-between">
         <span class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Segment</span>

--- a/web/src/views/ServiceView.vue
+++ b/web/src/views/ServiceView.vue
@@ -91,7 +91,7 @@ watch(
   />
 
   <GlobalNotice v-if="isGlobal" title="Service" />
-  <div v-else class="space-y-6 p-8">
+  <div v-else class="space-y-6 p-4 sm:p-8">
     <div v-if="loading" class="flex justify-center py-16"><Spinner class="size-6" /></div>
 
     <Card v-else-if="error">

--- a/web/src/views/SketchView.vue
+++ b/web/src/views/SketchView.vue
@@ -33,7 +33,8 @@ const newColor = ref('D82233')
 const newLabel = ref('')
 const addLabel = ref('')
 const addHex = ref('')
-const panelOpen = ref(true)
+// open where it can sit beside the canvas, closed where it would cover it
+const panelOpen = ref(window.matchMedia('(min-width: 1280px)').matches)
 
 let map: any = null
 let ro: ResizeObserver | null = null
@@ -756,7 +757,7 @@ watch(selId, () => nextTick(render))
     <div class="relative min-w-0 flex-1">
       <div ref="el" class="h-full w-full" :class="tool === 'draw' ? 'cursor-crosshair' : ''" />
 
-      <div class="pointer-events-none absolute inset-x-0 top-0 flex items-start justify-between gap-3 p-4">
+      <div class="pointer-events-none absolute inset-x-0 top-0 flex flex-wrap items-start justify-between gap-2 p-2 sm:gap-3 sm:p-4">
         <div class="pointer-events-auto flex items-center gap-2 rounded-xl border border-border bg-card/90 px-3 py-2 shadow-sm backdrop-blur">
           <span class="text-sm font-medium">{{ currentFeed?.name || 'No feed' }}</span>
           <Badge v-if="loading" variant="info"><Spinner class="size-3" /> loading</Badge>
@@ -788,7 +789,7 @@ watch(selId, () => nextTick(render))
 
     <aside
       v-show="panelOpen"
-      class="absolute right-0 top-0 z-20 flex h-full w-80 flex-col overflow-y-auto border-l border-border bg-card shadow-xl xl:static xl:z-auto xl:bg-card/40 xl:shadow-none"
+      class="absolute right-0 top-0 z-20 flex h-full w-80 max-w-[85vw] flex-col overflow-y-auto border-l border-border bg-card shadow-xl xl:static xl:z-auto xl:bg-card/40 xl:shadow-none"
     >
       <div class="border-b border-border p-4">
         <div class="mb-2 flex items-center justify-between">

--- a/web/src/views/StyleView.vue
+++ b/web/src/views/StyleView.vue
@@ -271,7 +271,7 @@ const overrideCount = computed(
   </PageHeader>
 
   <GlobalNotice v-if="isGlobal" title="Style" />
-  <div v-else class="space-y-6 p-8">
+  <div v-else class="space-y-6 p-4 sm:p-8">
     <div class="flex gap-2 rounded-lg border border-border bg-muted/40 p-3 text-xs text-muted-foreground">
       <Info class="mt-0.5 size-3.5 shrink-0" />
       <span v-if="scope === 'feed'">

--- a/web/src/views/TuningView.vue
+++ b/web/src/views/TuningView.vue
@@ -136,7 +136,7 @@ async function buildWith() {
   </PageHeader>
 
   <GlobalNotice v-if="isGlobal" title="Tuning" />
-  <div v-else class="space-y-6 p-8">
+  <div v-else class="space-y-6 p-4 sm:p-8">
     <div class="flex gap-2 rounded-lg border border-border bg-muted/40 p-3 text-xs text-muted-foreground">
       <Info class="mt-0.5 size-3.5 shrink-0" />
       <span>


### PR DESCRIPTION
The console was desktop-only: a fixed 240px sidebar ate half a phone screen and the layer panel covered a third of the map (screenshot in the session that prompted this).

- **Sidebar → drawer below `md`.** A hamburger top bar opens it over an overlay; navigating closes it. Desktop layout unchanged.
- **Layer picker collapsed by default** on every screen size — a single `Layers` button in the corner; the open panel gets a fold-back header, a height cap, and scrolls.
- **Map overlays fit a phone**: the toolbar truncates the feed name instead of overflowing, the segment inspector goes full-width at the bottom, the zoom/coords readout steps aside for it.
- **Pages**: `p-8` → `p-4 sm:p-8` everywhere, PageHeader likewise; feed-editor dialog grids collapse to one column and the dialog keeps a 1rem margin; sketch panel starts closed below `xl` and never exceeds 85vw.
- **`h-screen` → `h-dvh`** so bottom-anchored overlays sit above mobile browser chrome.

`bun run typecheck` and `bun run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)