### PR TITLE
Patch imports, per-route service hours, and the bullet vocabulary the tiles publish

### DIFF
--- a/cmd/portolan/main.go
+++ b/cmd/portolan/main.go
@@ -789,8 +789,9 @@ var syncCmd = &command{
 moved (by the registry's onestop ids), diffs against the state manifest,
 and downloads what changed into --data. patch rebuilds exactly the
 builds whose inputs changed; global is the same executor with every
-feed in the changed set — the oracle patch must match. patch and global
-are not yet implemented; check works today.
+feed in the changed set — the oracle patch must match. check works
+today; patch and global plan (--dry-run: measure shared steel,
+re-derive groups, print the rebuild closure) but do not yet execute.
 
 TRANSITLAND_API_KEY is read from the environment. Feed entries without
 an onestop id are reported and skipped. A new upstream sha over
@@ -893,20 +894,95 @@ func runSyncCheck(sf *syncFlags) {
 	}
 }
 
-// runSyncStub: patch and global parse their flags today and land in a
-// later phase; --dry-run says what the run would have done, so the
-// operator can see the plan before the executor exists.
+// runSyncStub: the PLANNER is real — measurement, group re-derivation,
+// the rebuild closure, the registry rewrite payload — and --dry-run
+// prints it. Execution (actually rebuilding) is the next phase; a
+// non-dry run refuses before measuring anything.
 func runSyncStub(sub string, sf *syncFlags) {
-	if sf.dryRun {
-		scope := "every registered feed"
-		if sub == "patch" {
-			scope = "feeds " + sf.feeds
-		}
-		fmt.Printf("sync %s would: take %s as the changed set, measure the affected\n", sub, scope)
-		fmt.Printf("closure (shared steel, groups, overlays — docs/SYNC.md), rebuild those\n")
-		fmt.Printf("builds into %s, retile into %s, export corrected GTFS\n", sf.build, sf.tiles)
-		fmt.Printf("into %s, and record each stage in %s\n", sf.exportGTFS, sf.state)
+	if !sf.dryRun {
+		fmt.Fprintf(os.Stderr, "portolan: sync %s is not yet implemented — sync check and --dry-run work today\n", sub)
+		os.Exit(1)
 	}
-	fmt.Fprintf(os.Stderr, "portolan: sync %s is not yet implemented — sync check works today\n", sub)
-	os.Exit(1)
+	cfg, err := registry.Load(sf.config)
+	die(err)
+	doc, err := sync.LoadDoc(sf.config)
+	die(err)
+	st, err := sync.LoadState(sf.state)
+	die(err)
+	var changed []string
+	if sub == "patch" {
+		for _, k := range strings.Split(sf.feeds, ",") {
+			if k = strings.TrimSpace(k); k != "" {
+				changed = append(changed, k)
+			}
+		}
+	}
+	plan, err := sync.BuildPlan(sync.PlanOpts{
+		Config: cfg, Doc: doc, State: st,
+		Changed: changed, BuildDir: sf.build, Global: sub == "global",
+		Log: func(f string, a ...any) { fmt.Fprintf(os.Stderr, f+"\n", a...) },
+	})
+	die(err)
+	printPlan(plan)
+	if sf.jsonOut {
+		b, _ := json.Marshal(map[string]any{
+			"changed": plan.Changed, "affected": plan.Affected,
+			"standalone": plan.Standalone, "member_pyramids": plan.MemberPyramids,
+			"groups": plan.Groups, "groups_created": plan.GroupsCreated,
+			"groups_deleted": plan.GroupsDeleted, "overlays": plan.Overlays,
+			"groups_rewritten": plan.RegistryChanged,
+		})
+		fmt.Printf("RESULT %s\n", b)
+	}
+}
+
+// printPlan: the derivation the way groups.py reports it, then the
+// rebuild closure — what a non-dry run would do, in execution order.
+func printPlan(p *sync.Plan) {
+	d := p.Derivation
+	dups := make([]string, 0, len(d.Duplicate))
+	for lo := range d.Duplicate {
+		dups = append(dups, lo)
+	}
+	sort.Strings(dups)
+	for _, lo := range dups {
+		fmt.Printf("  duplicate: %s is %s again — held out\n", lo, d.Duplicate[lo])
+	}
+	for _, k := range d.Undrawn {
+		fmt.Printf("  undrawn:   %s has no build — held out\n", k)
+	}
+	for _, g := range d.Groups {
+		e := g.Extent
+		fmt.Printf("[%.2f,%.2f,%.2f,%.2f]  %.2f deg2\n", e[0], e[1], e[2], e[3], e.Area())
+		for _, m := range g.Members {
+			fmt.Printf("    member  %s\n", m)
+		}
+		for _, o := range g.Overlays {
+			var km float64
+			for _, m := range g.Members {
+				if s := d.SharedM(o, m); s > km {
+					km = s
+				}
+			}
+			fmt.Printf("    overlay %s  (%.0f km shared)\n", o, km/1000)
+		}
+	}
+	fmt.Printf("\nplan: %d changed, %d measured, %d affected\n",
+		len(p.Changed), len(p.Measured), len(p.Affected))
+	list := func(name string, ks []string) {
+		if len(ks) > 0 {
+			fmt.Printf("  %-20s %s\n", name, strings.Join(ks, " "))
+		}
+	}
+	list("rebuild standalone:", p.Standalone)
+	list("rebuild groups:", p.Groups)
+	list("  created:", p.GroupsCreated)
+	list("  deleted:", p.GroupsDeleted)
+	list("overlay backgrounds:", p.Overlays)
+	list("member pyramids:", p.MemberPyramids)
+	if p.RegistryChanged {
+		fmt.Printf("  registry rewrite:    yes (%d bytes)\n", len(p.Registry))
+	} else {
+		fmt.Printf("  registry rewrite:    no\n")
+	}
 }

--- a/cmd/portolan/main.go
+++ b/cmd/portolan/main.go
@@ -787,11 +787,12 @@ var syncCmd = &command{
 	},
 	about: `Keeps a fleet of feeds current. check asks transitland which feeds
 moved (by the registry's onestop ids), diffs against the state manifest,
-and downloads what changed into --data. patch rebuilds exactly the
-builds whose inputs changed; global is the same executor with every
-feed in the changed set — the oracle patch must match. check works
-today; patch and global plan (--dry-run: measure shared steel,
-re-derive groups, print the rebuild closure) but do not yet execute.
+downloads what changed into --data, and then runs the patch flow on the
+changed set. patch rebuilds exactly the builds whose inputs changed —
+measure shared steel, re-derive groups, rewrite the registry, build,
+verify, tile, export; global is the same executor with every on-disk
+feed in the changed set, and is the oracle patch must match byte for
+byte. --dry-run prints the plan and stops before touching anything.
 
 TRANSITLAND_API_KEY is read from the environment. Feed entries without
 an onestop id are reported and skipped. A new upstream sha over
@@ -817,7 +818,7 @@ hash is the identity that matters (docs/SYNC.md).`,
 		fs.StringVar(&s.state, "state", "", "state manifest (default <build>/sync-state.json)")
 		fs.StringVar(&s.styleDir, "style-dir", style.DefaultDir, "curation directory")
 		fs.StringVar(&s.feeds, "feeds", "", "comma list of feed keys (patch only)")
-		fs.IntVar(&s.jobs, "jobs", runtime.NumCPU(), "parallel feed builds")
+		fs.IntVar(&s.jobs, "jobs", sync.DefaultJobs(), "parallel feed builds (chart is memory-heavy; the default is deliberately modest)")
 		fs.BoolVar(&s.dryRun, "dry-run", false, "plan only: print what would happen, change nothing")
 		fs.BoolVar(&s.jsonOut, "json", false, "final stdout line is RESULT {…} for a supervising process")
 		return s
@@ -868,7 +869,48 @@ func runSync(args []string) {
 		runSyncCheck(sf)
 		return
 	}
-	runSyncStub(sub, sf)
+	runSyncPatchGlobal(sub, sf)
+}
+
+// resultLine is the machine-readable last stdout line under --json —
+// the barrelman contract (docs/SYNC.md). One schema for check, patch
+// and global; check's original {changed, skipped, errors} keys are all
+// present, so its parser keeps working.
+type resultLine struct {
+	Changed         []string       `json:"changed"`
+	Affected        []string       `json:"affected"`
+	Rebuilt         []string       `json:"rebuilt"`
+	GroupsRewritten bool           `json:"groups_rewritten"`
+	Tiles           sync.TileTally `json:"tiles"`
+	Exported        []string       `json:"exported"`
+	Skipped         []string       `json:"skipped"`
+	Errors          []string       `json:"errors"`
+}
+
+func emitResult(sf *syncFlags, rl resultLine) {
+	if !sf.jsonOut {
+		return
+	}
+	if rl.Changed == nil {
+		rl.Changed = []string{}
+	}
+	if rl.Affected == nil {
+		rl.Affected = []string{}
+	}
+	if rl.Rebuilt == nil {
+		rl.Rebuilt = []string{}
+	}
+	if rl.Exported == nil {
+		rl.Exported = []string{}
+	}
+	if rl.Skipped == nil {
+		rl.Skipped = []string{}
+	}
+	if rl.Errors == nil {
+		rl.Errors = []string{}
+	}
+	b, _ := json.Marshal(rl)
+	fmt.Printf("RESULT %s\n", b)
 }
 
 func runSyncCheck(sf *syncFlags) {
@@ -885,30 +927,27 @@ func runSyncCheck(sf *syncFlags) {
 	die(err)
 	fmt.Printf("%d changed, %d skipped, %d errors\n",
 		len(res.Changed), len(res.Skipped), len(res.Errors))
-	if sf.jsonOut {
-		b, _ := json.Marshal(res)
-		fmt.Printf("RESULT %s\n", b)
+	rl := resultLine{Changed: res.Changed, Skipped: res.Skipped, Errors: res.Errors}
+	// check hands into the patch flow: the downloaded changed set is
+	// planned and executed exactly as `sync patch --feeds` would.
+	// --dry-run stops after the diff, touching nothing.
+	if !sf.dryRun && len(res.Changed) > 0 {
+		run := execSync(sf, res.Changed, false)
+		rl = run
+		rl.Skipped = res.Skipped
+		rl.Errors = append(res.Errors, run.Errors...)
 	}
-	if len(res.Errors) > 0 {
+	emitResult(sf, rl)
+	if len(rl.Errors) > 0 {
 		os.Exit(1)
 	}
 }
 
-// runSyncStub: the PLANNER is real — measurement, group re-derivation,
-// the rebuild closure, the registry rewrite payload — and --dry-run
-// prints it. Execution (actually rebuilding) is the next phase; a
-// non-dry run refuses before measuring anything.
-func runSyncStub(sub string, sf *syncFlags) {
-	if !sf.dryRun {
-		fmt.Fprintf(os.Stderr, "portolan: sync %s is not yet implemented — sync check and --dry-run work today\n", sub)
-		os.Exit(1)
-	}
-	cfg, err := registry.Load(sf.config)
-	die(err)
-	doc, err := sync.LoadDoc(sf.config)
-	die(err)
-	st, err := sync.LoadState(sf.state)
-	die(err)
+// runSyncPatchGlobal plans, prints the plan, and — unless --dry-run —
+// executes it (internal/sync.Run): registry rewrite, builds under
+// --jobs child processes, group verify gates, tiling, style manifests,
+// the static tile index, exports and the state manifest.
+func runSyncPatchGlobal(sub string, sf *syncFlags) {
 	var changed []string
 	if sub == "patch" {
 		for _, k := range strings.Split(sf.feeds, ",") {
@@ -917,23 +956,78 @@ func runSyncStub(sub string, sf *syncFlags) {
 			}
 		}
 	}
+	rl := execSync(sf, changed, sub == "global")
+	emitResult(sf, rl)
+	if len(rl.Errors) > 0 {
+		os.Exit(1)
+	}
+}
+
+// execSync is the shared plan-and-execute body of patch, global and the
+// tail of check. It dies on run-level failures and returns the RESULT
+// payload for everything else.
+func execSync(sf *syncFlags, changed []string, global bool) resultLine {
+	cfg, err := registry.Load(sf.config)
+	die(err)
+	doc, err := sync.LoadDoc(sf.config)
+	die(err)
+	st, err := sync.LoadState(sf.state)
+	die(err)
+	// global operates on what is local: a registry row whose zip was
+	// never downloaded is reported, not fatal — most of the registry is
+	// undownloaded discovery output
+	var skipped []string
+	if global {
+		for k, fc := range cfg.Feeds {
+			if len(fc.Members) > 0 || fc.PrimaryGTFS() == "" {
+				continue
+			}
+			if _, err := os.Stat(fc.PrimaryGTFS()); err != nil {
+				skipped = append(skipped, k)
+			}
+		}
+		sort.Strings(skipped)
+		if len(skipped) > 0 {
+			fmt.Printf("global: %d feeds have no zip on disk — skipped\n", len(skipped))
+		}
+	}
 	plan, err := sync.BuildPlan(sync.PlanOpts{
 		Config: cfg, Doc: doc, State: st,
-		Changed: changed, BuildDir: sf.build, Global: sub == "global",
-		Log: func(f string, a ...any) { fmt.Fprintf(os.Stderr, f+"\n", a...) },
+		Changed: changed, BuildDir: sf.build, Global: global,
+		Log: func(f string, a ...any) { fmt.Printf(f+"\n", a...) },
 	})
 	die(err)
 	printPlan(plan)
-	if sf.jsonOut {
-		b, _ := json.Marshal(map[string]any{
-			"changed": plan.Changed, "affected": plan.Affected,
-			"standalone": plan.Standalone, "member_pyramids": plan.MemberPyramids,
-			"groups": plan.Groups, "groups_created": plan.GroupsCreated,
-			"groups_deleted": plan.GroupsDeleted, "overlays": plan.Overlays,
-			"groups_rewritten": plan.RegistryChanged,
-		})
-		fmt.Printf("RESULT %s\n", b)
+	planned := map[string]bool{}
+	for _, ks := range [][]string{plan.Standalone, plan.Overlays, plan.MemberPyramids, plan.Groups} {
+		for _, k := range ks {
+			planned[k] = true
+		}
 	}
+	var rebuilt []string
+	for k := range planned {
+		rebuilt = append(rebuilt, k)
+	}
+	sort.Strings(rebuilt)
+	if sf.dryRun {
+		return resultLine{Changed: plan.Changed, Affected: plan.Affected,
+			Rebuilt: rebuilt, GroupsRewritten: plan.RegistryChanged, Skipped: skipped}
+	}
+	exe, err := os.Executable()
+	die(err)
+	res, err := sync.Run(plan, sync.RunOpts{
+		ConfigPath: sf.config, StatePath: sf.state,
+		BuildDir: sf.build, TilesDir: sf.tiles, ExportDir: sf.exportGTFS,
+		StyleDir: sf.styleDir, Jobs: sf.jobs, Portolan: exe,
+		Log: func(f string, a ...any) { fmt.Printf(f+"\n", a...) },
+	})
+	die(err)
+	fmt.Printf("done: %d rebuilt, tiles %d written / %d unchanged / %d removed, %d exported, %d errors\n",
+		len(res.Rebuilt), res.Tiles.Written, res.Tiles.Unchanged, res.Tiles.Removed,
+		len(res.Exported), len(res.Errors))
+	return resultLine{Changed: res.Changed, Affected: res.Affected,
+		Rebuilt: res.Rebuilt, GroupsRewritten: res.GroupsRewritten,
+		Tiles: res.Tiles, Exported: res.Exported, Skipped: skipped, Errors: res.Errors}
 }
 
 // printPlan: the derivation the way groups.py reports it, then the

--- a/cmd/portolan/main.go
+++ b/cmd/portolan/main.go
@@ -19,16 +19,18 @@ import (
 	"runtime/debug"
 	"runtime/pprof"
 	"sort"
-	"time"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/alexwohlbruck/portolan/internal/atlas"
 	"github.com/alexwohlbruck/portolan/internal/geo"
 	"github.com/alexwohlbruck/portolan/internal/gtfs"
 	"github.com/alexwohlbruck/portolan/internal/pipeline"
+	"github.com/alexwohlbruck/portolan/internal/registry"
 	"github.com/alexwohlbruck/portolan/internal/serve"
 	"github.com/alexwohlbruck/portolan/internal/style"
+	"github.com/alexwohlbruck/portolan/internal/sync"
 	"github.com/alexwohlbruck/portolan/internal/tiles"
 )
 
@@ -47,6 +49,10 @@ type command struct {
 	// flags registers the command's flags; run does the work.
 	flags func(*flag.FlagSet) any
 	run   func(*flag.FlagSet, any)
+	// raw, when set, takes over argument handling entirely — for a
+	// command whose first argument is a verb, not a flag (sync
+	// check|patch|global). printHelp still reads flags as usual.
+	raw func(args []string)
 }
 
 type flagGroup struct {
@@ -57,7 +63,10 @@ type flagGroup struct {
 var commands []*command
 
 func init() {
-	commands = []*command{chartCmd, soundCmd, scenariosCmd, tilesCmd, atlasCmd, serveCmd}
+	commands = []*command{chartCmd, soundCmd, scenariosCmd, tilesCmd, syncCmd, atlasCmd, serveCmd}
+	// wired here, not in the literal: runSync prints syncCmd's help, and
+	// the compiler calls that reference an initialization cycle
+	syncCmd.raw = runSync
 }
 
 func main() {
@@ -106,6 +115,10 @@ func find(name string) *command {
 // help, not a usage error — while a genuine mistake goes to stderr with
 // a pointer to the right help page and exits 2.
 func (c *command) exec(args []string) {
+	if c.raw != nil {
+		c.raw(args)
+		return
+	}
 	fs := flag.NewFlagSet(c.name, flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	cfg := c.flags(fs)
@@ -738,4 +751,147 @@ bullets at z12, matching the viewer's own symbol floors. A tiles.json
 		fmt.Printf("%d tiles written (%.1f MB), %d unchanged, %d pruned → %s\n",
 			st.Tiles, float64(st.Bytes)/1e6, st.Unchanged, st.Removed, t.out)
 	},
+}
+
+// ------------------------------------------------------------ sync
+
+type syncFlags struct {
+	config, data, build, tiles, exportGTFS string
+	state, styleDir, feeds                 string
+	jobs                                   int
+	dryRun, jsonOut                        bool
+}
+
+var syncCmd = &command{
+	name:    "sync",
+	summary: "reconcile the feed fleet against upstream (docs/SYNC.md)",
+	usage: []string{
+		"sync check  --config portolan.json [flags]",
+		"sync patch  --config portolan.json --feeds key1,key2 [flags]",
+		"sync global --config portolan.json [flags]",
+	},
+	about: `Keeps a fleet of feeds current. check asks transitland which feeds
+moved (by the registry's onestop ids), diffs against the state manifest,
+and downloads what changed into --data. patch rebuilds exactly the
+builds whose inputs changed; global is the same executor with every
+feed in the changed set — the oracle patch must match. patch and global
+are not yet implemented; check works today.
+
+TRANSITLAND_API_KEY is read from the environment. Feed entries without
+an onestop id are reported and skipped. A new upstream sha over
+identical content records the sha and rebuilds nothing — the content
+hash is the identity that matters (docs/SYNC.md).`,
+	groups: []flagGroup{
+		{"inputs", []string{"config", "data", "feeds"}},
+		{"outputs", []string{"build", "tiles", "export-gtfs", "state", "style-dir"}},
+		{"run", []string{"jobs", "dry-run", "json"}},
+	},
+	example: []string{
+		"portolan sync check --config portolan.json --dry-run",
+		"portolan sync check --config portolan.json --json",
+		"portolan sync patch --config portolan.json --feeds mta-subway",
+	},
+	flags: func(fs *flag.FlagSet) any {
+		s := &syncFlags{}
+		fs.StringVar(&s.config, "config", "portolan.json", "feed registry")
+		fs.StringVar(&s.data, "data", "data/gtfs", "where GTFS zips live / are downloaded")
+		fs.StringVar(&s.build, "build", "build", "build fan output dir")
+		fs.StringVar(&s.tiles, "tiles", "build/tiles", "tile pyramids + index.json")
+		fs.StringVar(&s.exportGTFS, "export-gtfs", "build/export", "corrected GTFS zips (empty = skip export)")
+		fs.StringVar(&s.state, "state", "", "state manifest (default <build>/sync-state.json)")
+		fs.StringVar(&s.styleDir, "style-dir", style.DefaultDir, "curation directory")
+		fs.StringVar(&s.feeds, "feeds", "", "comma list of feed keys (patch only)")
+		fs.IntVar(&s.jobs, "jobs", runtime.NumCPU(), "parallel feed builds")
+		fs.BoolVar(&s.dryRun, "dry-run", false, "plan only: print what would happen, change nothing")
+		fs.BoolVar(&s.jsonOut, "json", false, "final stdout line is RESULT {…} for a supervising process")
+		return s
+	},
+	// raw is runSync, assigned in init() to break an initialization cycle
+}
+
+func runSync(args []string) {
+	if len(args) == 0 {
+		fail("sync needs a subcommand: check, patch or global\ntry: portolan help sync")
+	}
+	sub := args[0]
+	switch sub {
+	case "help", "-h", "--help":
+		syncCmd.printHelp(os.Stdout)
+		return
+	case "check", "patch", "global":
+	default:
+		fail("sync %q: want check, patch or global\ntry: portolan help sync", sub)
+	}
+	fs := flag.NewFlagSet("sync "+sub, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sf := syncCmd.flags(fs).(*syncFlags)
+	if err := fs.Parse(args[1:]); err != nil {
+		if err == flag.ErrHelp {
+			syncCmd.printHelp(os.Stdout)
+			return
+		}
+		fmt.Fprintf(os.Stderr, "portolan sync %s: %v\n", sub, err)
+		fmt.Fprintf(os.Stderr, "try: portolan help sync\n")
+		os.Exit(2)
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "portolan sync %s: unexpected argument %q — flags only\n", sub, fs.Arg(0))
+		fmt.Fprintf(os.Stderr, "try: portolan help sync\n")
+		os.Exit(2)
+	}
+	if sub == "patch" && sf.feeds == "" {
+		fail("sync patch needs --feeds: the keys whose zips changed\ntry: portolan help sync")
+	}
+	if sub != "patch" && sf.feeds != "" {
+		fail("--feeds is a patch flag — %s finds the changed set itself", sub)
+	}
+	if sf.state == "" {
+		sf.state = filepath.Join(sf.build, "sync-state.json")
+	}
+	if sub == "check" {
+		runSyncCheck(sf)
+		return
+	}
+	runSyncStub(sub, sf)
+}
+
+func runSyncCheck(sf *syncFlags) {
+	cfg, err := registry.Load(sf.config)
+	die(err)
+	res, err := sync.Check(sync.CheckOpts{
+		Config:    cfg,
+		StatePath: sf.state,
+		DataDir:   sf.data,
+		Client:    sync.NewClient(os.Getenv("TRANSITLAND_API_KEY")),
+		DryRun:    sf.dryRun,
+		Log:       func(f string, a ...any) { fmt.Printf(f+"\n", a...) },
+	})
+	die(err)
+	fmt.Printf("%d changed, %d skipped, %d errors\n",
+		len(res.Changed), len(res.Skipped), len(res.Errors))
+	if sf.jsonOut {
+		b, _ := json.Marshal(res)
+		fmt.Printf("RESULT %s\n", b)
+	}
+	if len(res.Errors) > 0 {
+		os.Exit(1)
+	}
+}
+
+// runSyncStub: patch and global parse their flags today and land in a
+// later phase; --dry-run says what the run would have done, so the
+// operator can see the plan before the executor exists.
+func runSyncStub(sub string, sf *syncFlags) {
+	if sf.dryRun {
+		scope := "every registered feed"
+		if sub == "patch" {
+			scope = "feeds " + sf.feeds
+		}
+		fmt.Printf("sync %s would: take %s as the changed set, measure the affected\n", sub, scope)
+		fmt.Printf("closure (shared steel, groups, overlays — docs/SYNC.md), rebuild those\n")
+		fmt.Printf("builds into %s, retile into %s, export corrected GTFS\n", sf.build, sf.tiles)
+		fmt.Printf("into %s, and record each stage in %s\n", sf.exportGTFS, sf.state)
+	}
+	fmt.Fprintf(os.Stderr, "portolan: sync %s is not yet implemented — sync check works today\n", sub)
+	os.Exit(1)
 }

--- a/cmd/portolan/main.go
+++ b/cmd/portolan/main.go
@@ -296,6 +296,7 @@ type chartFlags struct {
 	styleDir, city, stylePath, lineAgency string
 	scenario                              string
 	exportGTFS                            string
+	onestop                               string
 	set                                   string
 	allowUnmatched                        bool
 	cover                                 float64
@@ -322,7 +323,7 @@ and stops: a quick check that an OSM extract is usable, with no map.`,
 	groups: []flagGroup{
 		{"inputs", []string{"gtfs", "rail", "corridors", "corridor-nodes", "streets", "stops"}},
 		{"window and projection", []string{"bbox", "exclude-bbox", "anchor"}},
-		{"output", []string{"out", "format", "band", "export-gtfs", "set", "allow-unmatched"}},
+		{"output", []string{"out", "format", "band", "export-gtfs", "onestop", "set", "allow-unmatched"}},
 		{"curation", []string{"style-dir", "feed", "style", "line-agencies"}},
 		{"service", []string{"scenario", "cover"}},
 	},
@@ -354,6 +355,7 @@ and stops: a quick check that an OSM extract is usable, with no map.`,
 		fs.StringVar(&c.lineAgency, "line-agencies", "", "comma list: regional agencies keeping per-line colours")
 		fs.StringVar(&c.scenario, "scenario", "", "build one service scenario (see `portolan scenarios`)")
 		fs.StringVar(&c.exportGTFS, "export-gtfs", "", "directory: write the source feeds back out with matched shapes.txt")
+		fs.StringVar(&c.onestop, "onestop", "", "onestop id per source zip, by basename: key=f-…[,key=f-…] — stations carry gtfs_ids")
 		fs.StringVar(&c.set, "set", "", "tuning overrides: key=val[,key=val] over the defaults (keys as in the atlas tuning panel, e.g. join_tol=120)")
 		fs.BoolVar(&c.allowUnmatched, "allow-unmatched", false, "ship rail patterns that failed to path-match (default: the build fails)")
 		fs.Float64Var(&c.cover, "cover", 0.99, "pattern trip-coverage fraction")
@@ -475,6 +477,19 @@ func runChart(c *chartFlags) {
 	if c.lineAgency != "" {
 		las = strings.Split(c.lineAgency, ",")
 	}
+	// --onestop: zip basename (sans .zip) → onestop id. Sync fills the
+	// same map from the registry; this flag is the by-hand route.
+	var onestop map[string]string
+	if c.onestop != "" {
+		onestop = map[string]string{}
+		for _, kv := range strings.Split(c.onestop, ",") {
+			k, v, ok := strings.Cut(strings.TrimSpace(kv), "=")
+			if !ok || k == "" || v == "" {
+				fail("--onestop wants key=onestop-id[,key=onestop-id]\ntry: portolan help chart")
+			}
+			onestop[strings.TrimSuffix(k, ".zip")] = v
+		}
+	}
 	// Curation resolves through the SAME loader the atlas uses, so a CLI
 	// build and a dashboard build of one city cannot disagree.
 	var sty *style.Set
@@ -521,7 +536,7 @@ func runChart(c *chartFlags) {
 	die(pipeline.Chart(pipeline.ChartOpts{
 		GTFS: c.gtfs, Rail: c.rail, Streets: c.streets, Stops: c.stops, BBox: bbox, Exclude: exclude,
 		Corridors: c.corridors, CorridorNodes: c.corridorNodes, Anchor: anchorLL,
-		LineAgencies: las, Scenario: c.scenario, Style: sty, ExportGTFS: c.exportGTFS, AllowUnmatched: c.allowUnmatched,
+		LineAgencies: las, Scenario: c.scenario, Style: sty, ExportGTFS: c.exportGTFS, Onestop: onestop, AllowUnmatched: c.allowUnmatched,
 		Out: out, Format: c.format, Band: bandPtr, Dials: &d,
 	}, func(f string, a ...any) { fmt.Fprintf(os.Stderr, f+"\n", a...) }))
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -462,6 +462,47 @@ for 30 minutes.
 
 ---
 
+## sync
+
+Reconcile the feed fleet against upstream — notice which GTFS feeds
+changed, download them, rebuild what their change touches. The full
+contract, including why a patch run must equal a global one, is
+[SYNC.md](SYNC.md).
+
+```
+portolan sync check  --config portolan.json [flags]
+portolan sync patch  --config portolan.json --feeds key1,key2 [flags]
+portolan sync global --config portolan.json [flags]
+```
+
+| flag | meaning |
+|---|---|
+| `--config` | Feed registry (default `portolan.json`). |
+| `--data` | Where GTFS zips live / are downloaded (default `data/gtfs`). |
+| `--feeds` | Comma list of feed keys — `patch` only. |
+| `--build` | Build fan output dir (default `build`). |
+| `--tiles` | Tile pyramids + index.json (default `build/tiles`). |
+| `--export-gtfs` | Corrected GTFS zips; empty skips export (default `build/export`). |
+| `--state` | State manifest (default `<build>/sync-state.json`). |
+| `--style-dir` | Curation directory (default `style`). |
+| `--jobs` | Parallel feed builds (default NumCPU). |
+| `--dry-run` | Plan only: print what would happen, change nothing. |
+| `--json` | Final stdout line is `RESULT {…}` for a supervising process. |
+
+`check` asks transitland for each registered feed's current version (by
+the registry's `onestop` id, `TRANSITLAND_API_KEY` from the environment),
+diffs against the manifest, and downloads what moved into `--data`. A new
+upstream sha over identical content records the sha and rebuilds nothing.
+`patch` and `global` are not yet implemented; their flags parse, and
+`--dry-run` prints the plan they will execute.
+
+```bash
+portolan sync check --dry-run              # what moved upstream?
+portolan sync check --json                 # download it, tell barrelman
+```
+
+---
+
 ## Recipes
 
 ```bash

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -485,20 +485,28 @@ portolan sync global --config portolan.json [flags]
 | `--export-gtfs` | Corrected GTFS zips; empty skips export (default `build/export`). |
 | `--state` | State manifest (default `<build>/sync-state.json`). |
 | `--style-dir` | Curation directory (default `style`). |
-| `--jobs` | Parallel feed builds (default NumCPU). |
+| `--jobs` | Parallel feed builds (default min(4, NumCPU) — charts are memory-heavy). |
 | `--dry-run` | Plan only: print what would happen, change nothing. |
 | `--json` | Final stdout line is `RESULT {…}` for a supervising process. |
 
 `check` asks transitland for each registered feed's current version (by
 the registry's `onestop` id, `TRANSITLAND_API_KEY` from the environment),
-diffs against the manifest, and downloads what moved into `--data`. A new
-upstream sha over identical content records the sha and rebuilds nothing.
-`patch` and `global` are not yet implemented; their flags parse, and
-`--dry-run` prints the plan they will execute.
+diffs against the manifest, downloads what moved into `--data`, and runs
+the patch flow on the changed set. A new upstream sha over identical
+content records the sha and rebuilds nothing. `patch` rebuilds exactly
+the builds whose inputs the named feeds touch — shared-steel
+measurement, group re-derivation, registry rewrite, builds (each a
+`portolan chart` child process), the ink-retention verify gate on every
+group, tiling, GTFS export, the static tile index. `global` is the same
+executor with every on-disk feed in the changed set — the oracle a patch
+must match byte for byte; registry entries whose zip was never
+downloaded are reported and skipped.
 
 ```bash
 portolan sync check --dry-run              # what moved upstream?
-portolan sync check --json                 # download it, tell barrelman
+portolan sync check --json                 # download + rebuild it, tell barrelman
+portolan sync patch --feeds mta-subway     # rebuild one feed's closure
+portolan sync global --json                # rebuild the world, report
 ```
 
 ---

--- a/docs/DYNAMIC-SERVICE.md
+++ b/docs/DYNAMIC-SERVICE.md
@@ -72,6 +72,19 @@ AND of their two sides — a movement runs only when the route rides both.
 Route-level masks (/api/activity) remain as the toolbar summary and the
 fallback for builds that predate acts.
 
+Each ribbon also carries `ridx`, naming the slot every route owns in its
+own `acts` string: `"A=00;C=01;E=02"`. The masks ride at a fixed stride,
+so a consumer that knows the slot can read ONE route's hours exactly —
+but a renderer's filter expression can slice a string at a computed
+offset and cannot count the commas in `routes`, and route ids are not
+fixed width. Publishing the slot costs two digits per route, a fifth of
+what repeating the masks would, and it is what lets a client isolate a
+single line honestly: "is the 3 running on this track" rather than "is
+anything running on this track", which on shared trunk (2/3, A/C — most
+of a big system) are different questions with different answers at 3am.
+Absent on builds that predate it, and a consumer should fall back to the
+per-segment union rather than drawing nothing.
+
 The mid-edge short-turn residual is RESOLVED by terminal cuts
 (stages.CutSegmentsAtTerminals, a post-FAIR pass): emitted segments are
 cut at mid-segment pattern terminals — anchored at the pattern's

--- a/docs/STOP-LABELS.md
+++ b/docs/STOP-LABELS.md
@@ -269,8 +269,10 @@ is one-to-one and greedy by score. The extract is opt-in per city, and its
 presence IS the switch — a city with no `stops` path is untouched.
 
 A match always attaches the OSM object id, emitted as `osm` on the station
-feature (`"node/5106080553"`), so a consumer can join a drawn station back
-to OpenStreetMap. Whether it also renames is the `osm_stop_names` knob
+feature and on each of its markers (`"node/5106080553"`), so a consumer
+can join a drawn station back to OpenStreetMap — and so a click on the
+transit layer and a click on the same platform as a basemap POI resolve to
+one place rather than two. Whether it also renames is the `osm_stop_names` knob
 (default on), and two laws constrain the rename:
 
 **A rename must ADD information.** OSM is not uniformly better. Mexico

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -1,0 +1,128 @@
+# SYNC — the reconciliation command
+
+`portolan sync` keeps a fleet of feeds current: it notices which GTFS feeds
+changed upstream, downloads them, rebuilds exactly the builds whose inputs
+changed, retiles those pyramids, and re-exports corrected GTFS. It is the
+single entry point an operator (or barrelman's ops worker) calls; everything
+it does is also achievable by hand with `chart`/`tiles`/`tools/feed.sh` — sync
+just automates the bookkeeping.
+
+Three subcommands:
+
+    portolan sync global  --config portolan.json [flags]
+    portolan sync patch   --config portolan.json --feeds key1,key2 [flags]
+    portolan sync check   --config portolan.json [flags]
+
+Common flags:
+
+    --config     portolan.json            feed registry (required)
+    --data       data/gtfs                where GTFS zips live / are downloaded
+    --build      build                    build fan output dir
+    --tiles      build/tiles             tile pyramids + index.json
+    --export-gtfs build/export           corrected GTFS zips (empty = skip export)
+    --state      <build>/sync-state.json state manifest
+    --style-dir  style                    curation documents
+    --jobs       NumCPU                   parallel feed builds
+    --dry-run                             plan only, print what would rebuild
+    --json                                final line of stdout is `RESULT {…}`
+
+`TRANSITLAND_API_KEY` is read from the environment for `check` and for any
+download.
+
+## Why patch equals global
+
+Every build is a pure function of its inputs: the GTFS zips named in its
+config entry, the rail/stops/streets extracts, the window (bbox +
+exclude-bbox), and the layered style documents. No build reads another
+build's output (a corridor input is a committed file, not a live edge).
+So the patch invariant is:
+
+> Rebuild every build whose input set changed; touch nothing else.
+> The resulting build/tiles/export trees are identical to a global run.
+
+The work is finding the closure of "input set changed":
+
+1. **Changed feeds** C — feeds whose zip content-hash differs from the state
+   manifest.
+2. **Interleaved neighbors** — feeds sharing steel with any feed in C. Shared
+   steel is a measurement, not curation (same rules as `tools/groups.py`):
+   sample rail-typed shapes every 30 m, bin into 60 m cells, a pair
+   qualifies at ≥900 m of co-occupied run. A bbox prefilter keeps this
+   cheap: only feeds whose window intersects a changed feed's window are
+   measured.
+3. **Group closure** — group membership is re-derived over the affected
+   component (the union-find component containing any feed in C, measured
+   with the same rules `tools/groups.py` uses). If membership, windows, or
+   the group's gtfs list changed, the group rebuilds. If a group appears or
+   dissolves, the config is rewritten the same way `groups.py --write`
+   would have.
+4. **Overlay closure** — an overlay (wide feed, e.g. Amtrak) whose
+   exclude-bbox set changed (because a group window moved) rebuilds its own
+   background build; groups it rides through already rebuild via (3).
+
+The rebuild set is then: standalone builds for affected non-member feeds,
+group builds for affected groups, overlay backgrounds when their windows
+changed. Members of surviving groups do not get standalone rebuilds (the
+global index skips them), but their per-feed pyramids rebuild if their own
+zip changed.
+
+`sync global` is the same executor with C = every feed, and serves as the
+oracle: `sync patch` after any single-feed change must produce byte-identical
+tiles to `sync global`. That equivalence is a test, not a hope.
+
+## State manifest
+
+`sync-state.json` records, per feed key:
+
+    {
+      "version": 1,
+      "last_check": "2026-08-20T04:00:00Z",
+      "feeds": {
+        "mta-subway": {
+          "onestop": "f-dr5r-nyct",
+          "sha1": "…",            // transitland feed_version sha at last download
+          "content": "…",         // sha256 over sorted *.txt members of the zip
+          "built": "…",           // content hash at last successful build
+          "tiled": "…",           // content hash at last successful tiling
+          "exported": "…"         // content hash at last successful export
+        }
+      }
+    }
+
+The content hash is the identity that matters (transitland occasionally
+republishes identical bytes under a new sha). A feed whose `content` equals
+`built`/`tiled`/`exported` is clean. Interrupted runs are safe: the manifest
+is written after each feed completes, so a rerun resumes where it stopped.
+
+## check
+
+For every feed entry with an `onestop` id, ask transitland for the current
+`feed_state.feed_version.sha1` (batched, `feeds/{onestop}`), diff against the
+manifest, download changed feeds into `--data` (via
+`download_latest_feed_version`, falling back to `urls.static_current`), then
+run the patch flow on the changed set. `--dry-run` stops after the diff.
+Feeds without an `onestop` id are reported and skipped. Exit 0 with
+`"changed": []` when nothing moved.
+
+## Machine-readable result
+
+With `--json`, the final stdout line is:
+
+    RESULT {"changed":["a"],"affected":["a","b","dallas"],
+            "rebuilt":["a","dallas"],"groups_rewritten":false,
+            "tiles":{"written":1234,"unchanged":56789,"removed":12},
+            "exported":["a.zip","amtrak.zip"],"errors":[]}
+
+Barrelman parses this line; everything above it is human progress output.
+A build failure for one feed does not abort the run — it lands in `errors`
+and the exit code is 1, with everything else completed.
+
+## What sync does not do
+
+- **Onboarding.** New feeds (Overpass extracts, pfaedle, discovery sweeps)
+  remain `tools/feed.sh` / `tools/onboard-*` territory. sync operates on
+  feeds the registry already describes with existing extracts.
+- **OSM refresh.** Rail/stops/streets extracts are inputs, not managed
+  artifacts. If an extract changes on disk, the affected feeds rebuild on
+  the next run (extract hashes participate in the input fingerprint).
+- **Serving.** The atlas serves; sync writes files.

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -22,7 +22,7 @@ Common flags:
     --export-gtfs build/export           corrected GTFS zips (empty = skip export)
     --state      <build>/sync-state.json state manifest
     --style-dir  style                    curation documents
-    --jobs       NumCPU                   parallel feed builds
+    --jobs       min(4, NumCPU)           parallel feed builds (charts are memory-heavy)
     --dry-run                             plan only, print what would rebuild
     --json                                final line of stdout is `RESULT {…}`
 
@@ -85,17 +85,27 @@ tiles to `sync global`. That equivalence is a test, not a hope.
           "onestop": "f-dr5r-nyct",
           "sha1": "…",            // transitland feed_version sha at last download
           "content": "…",         // sha256 over sorted *.txt members of the zip
-          "built": "…",           // content hash at last successful build
-          "tiled": "…",           // content hash at last successful tiling
-          "exported": "…"         // content hash at last successful export
+          "built": "…",           // input fingerprint at last successful build
+          "tiled": "…",           // input fingerprint at last successful tiling
+          "exported": "…"         // input fingerprint at last successful export
         }
       }
     }
 
 The content hash is the identity that matters (transitland occasionally
-republishes identical bytes under a new sha). A feed whose `content` equals
-`built`/`tiled`/`exported` is clean. Interrupted runs are safe: the manifest
-is written after each feed completes, so a rerun resumes where it stopped.
+republishes identical bytes under a new sha): `check` diffs it to decide
+what changed. `built`/`tiled`/`exported` hold the executor's **input
+fingerprint**: a hash over the assembled chart request (which folds in
+the registry entry, its window, the ceded exclude windows and the style
+layering) plus the content hash of every input zip. A build whose
+current fingerprint equals its stamps is clean and skips — this is what
+makes an overlay rebuild when only its ceded windows moved, and a group
+(whose row keys the group, not any single zip) rebuild when its
+membership changes. Extract and style-document contents are deliberately
+outside the fingerprint: the manifest covers the feed, by design — a
+curation change wants an explicit rebuild. Interrupted runs are safe:
+the manifest is written after each feed completes, so a rerun resumes
+where it stopped.
 
 ## check
 
@@ -104,25 +114,78 @@ For every feed entry with an `onestop` id, ask transitland for the current
 sequential, honoring a 429 once via Retry-After — the API has no batch
 lookup), diff against the manifest, download changed feeds into `--data` as
 `<feedkey>.zip` (via `download_latest_feed_version`, falling back to
-`urls.static_current`), then run the patch flow on the changed set. A new
-sha over identical content records the sha and changes nothing on disk.
+`urls.static_current`), then run the patch flow on the changed set:
+check → changed set → plan → execute, one command. A new sha over
+identical content records the sha and changes nothing on disk.
 `--dry-run` stops after the diff, touching neither `--data` nor the
 manifest. Feeds without an `onestop` id are reported and skipped. Exit 0
-with `"changed": []` when nothing moved; check's RESULT line carries
-`{"changed":[…],"skipped":[…],"errors":[…]}`.
+with `"changed": []` when nothing moved. A changed feed's zip is on disk
+before planning by construction — check downloaded it — which matters:
+the measurement reads it, and a patch planned over an absent zip would
+read a partial data tree as the railway vanishing.
 
 The `<feedkey>.zip` name is not a new convention: every onestop-bearing
 entry in portolan.json already points its primary gtfs at
 `data/gtfs/<feedkey>.zip`, so a download lands exactly where the feed's
 build reads.
 
-(Phasing: today check ends after download-and-record, and `sync patch
---dry-run` / `sync global --dry-run` print the real plan — measurement,
-group re-derivation, the rebuild closure, and whether the registry would
-be rewritten — without executing it. The executor that walks the plan is
-the next phase. A changed feed's zip must be on disk before planning:
-the measurement reads it, and a patch planned over an absent zip would
-read a partial data tree as the railway vanishing.)
+## Execution
+
+The executor walks a Plan in this order:
+
+1. **Registry.** If the plan rewrote it (groups created, dissolved,
+   windows moved), the new portolan.json is written first, atomically —
+   a crash after this point leaves a registry the next run re-plans
+   from correctly. Pyramids of deleted groups are removed. (Feeds newly
+   absorbed into a group keep their per-feed pyramids: the world index
+   skips grouped members, but the atlas still serves them feed-scoped.)
+2. **Builds**, under `--jobs` bounded parallelism. Every build in the
+   plan — standalone, overlay background, member pyramid, group — is
+   independent of every other (inputs are zips and extracts, never
+   another build's output), so they share one worker pool. Each build
+   runs as a `portolan chart` CHILD PROCESS with the argv
+   `tools/feed.sh build` would have assembled (gtfs list, geometry
+   source, window, ceded windows, style layering, `--onestop` from the
+   registry, `chart_args` word-split — parsed by chart's own flag set,
+   not a second parser); chart configuration is process state, so two
+   in-process builds would read each other's dials, and a child per
+   build also isolates its memory spike. Builds whose input fingerprint
+   already matches their state stamps are skipped.
+3. **Group preflight.** A group's rail extract that is missing or does
+   not cover the window is MERGED from its members' (and overlays')
+   extracts, first-wins on way id (the tools/mergefc.py rule — the same
+   OSM way must not enter the bundler twice); likewise a missing stops
+   extract, and `streets_from` into `streets`. sync never calls
+   Overpass — where groupbuild.sh would fetch, sync merges what the
+   members already have.
+4. **Verify gate**, immediately after each group's build: every
+   member's own band-15 non-transition centerlines, sampled at 25 m,
+   must land ≥90% within 30 m of the group's ink (tools/groupverify.py,
+   ported). A failing group is DELETED from the registry on the spot —
+   its members go straight back into the world index — its pyramid is
+   removed, the failure lands in `errors`, and any member without a
+   current standalone build joins the queue.
+5. **Tiles.** Each successful build is cut into `--tiles/<key>` and the
+   build's resolved style manifest (`<out>.style.json`) is copied into
+   the pyramid as `--tiles/<key>/style.json`. Differ stats aggregate
+   into the RESULT line.
+6. **Export.** With `--export-gtfs`, each feed-OWN build (standalone,
+   overlay background, member pyramid) writes its corrected zips into
+   the export dir. Group builds do not export: their member zips belong
+   to the members' own builds, and two builds writing one zip would
+   race — and which geometry won would depend on scheduling.
+7. **Index.** After all tiling, a static `--tiles/index.json` is
+   written: the same composer the atlas serves `/api/tiles/index.json`
+   from (internal/tiles.Index), over the post-run registry, so the
+   static file and the live endpoint cannot drift.
+8. **State**, stamped and saved after each feed completes — kill the
+   run anywhere and the rerun resumes, skipping what finished.
+
+`sync global` is the same executor with C = every feed whose zip is on
+disk. Registry entries whose zip was never downloaded (most of the
+registry is discovery output) are reported in `skipped`, not failed.
+Sound scoring (`portolan sound`) is not part of sync — it is advisory
+and feed.sh territory.
 
 ## Machine-readable result
 
@@ -131,7 +194,15 @@ With `--json`, the final stdout line is:
     RESULT {"changed":["a"],"affected":["a","b","dallas"],
             "rebuilt":["a","dallas"],"groups_rewritten":false,
             "tiles":{"written":1234,"unchanged":56789,"removed":12},
-            "exported":["a.zip","amtrak.zip"],"errors":[]}
+            "exported":["a.zip","amtrak.zip"],"skipped":[],"errors":[]}
+
+One schema for check, patch and global (check's original `changed`/
+`skipped`/`errors` keys are all present, so a parser built against it
+keeps working). `rebuilt` is the builds that actually ran — clean skips
+excluded; `exported` is exactly the `<feedkey>.zip` names present flat
+under the `--export-gtfs` dir; `skipped` is feeds without an onestop id
+(check) or without a zip on disk (global). `--dry-run` emits the same
+line with the planned rebuild set, zero tiles and exit 0.
 
 Barrelman parses this line; everything above it is human progress output.
 A build failure for one feed does not abort the run — it lands in `errors`
@@ -151,6 +222,19 @@ the station's name, and the label feature is the identity anchor.
 
 By hand the map arrives via `chart --onestop <zip-basename>=<onestop>,…`;
 sync fills it from the registry's `onestop` fields automatically.
+
+Each pyramid `--tiles/<feed>/` additionally carries:
+
+- `style.json` — the build's resolved style manifest (`<out>.style.json`
+  copied in), so the tile consumer fetches `<feed>/style.json` next to
+  the tiles it draws;
+- `tiles.json` — TileJSON with a single RELATIVE `{z}/{x}/{y}.mvt`
+  template, no hosts.
+
+Tiles are raw MVT, uncompressed. `--tiles/index.json` is the static
+world index: `[{feed,name,bounds,maxzoom}]`, the identical schema (and
+composer) the atlas serves at `/api/tiles/index.json`, carrying no URL
+templates.
 
 ## What sync does not do
 

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -242,6 +242,15 @@ Each pyramid `--tiles/<feed>/` additionally carries:
 - `style.json` — the build's resolved style manifest (`<out>.style.json`
   copied in), so the tile consumer fetches `<feed>/style.json` next to
   the tiles it draws;
+- `routes.json` — every route the pyramid draws, keyed by the id its
+  TILES use (prefixed as a group build prefixes them, `f3:2`), with the
+  bullet style already resolved: `{label, color, shape, mode}`. Curation
+  decides a bullet's outline — `shape:` on a route or its agency — and
+  the build resolves it and bakes the answer into the symbols; a consumer
+  that is not the map holds a route id from a routing engine and cannot
+  redo that, so the answer is published beside the tiles. An empty
+  `shape` is the default circle, exactly as the tiles carry it. Absent
+  for a pyramid with no drawn symbols at all (the bus-only feeds);
 - `tiles.json` — TileJSON with a single RELATIVE `{z}/{x}/{y}.mvt`
   template, no hosts.
 

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -179,7 +179,12 @@ The executor walks a Plan in this order:
    from (internal/tiles.Index), over the post-run registry, so the
    static file and the live endpoint cannot drift.
 8. **State**, stamped and saved after each feed completes — kill the
-   run anywhere and the rerun resumes, skipping what finished.
+   run anywhere and rerunning the SAME command resumes, skipping what
+   finished. One asymmetry to know: an interrupted `sync check` cannot
+   resume through check itself (the downloads are already recorded, so
+   the next check sees nothing changed) — run `sync global` to
+   converge, which is cheap when the world is clean: every current
+   build fingerprint-skips and only the genuinely unfinished work runs.
 
 `sync global` is the same executor with C = every feed whose zip is on
 disk. Registry entries whose zip was never downloaded (most of the
@@ -244,6 +249,8 @@ templates.
   remain `tools/feed.sh` / `tools/onboard-*` territory. sync operates on
   feeds the registry already describes with existing extracts.
 - **OSM refresh.** Rail/stops/streets extracts are inputs, not managed
-  artifacts. If an extract changes on disk, the affected feeds rebuild on
-  the next run (extract hashes participate in the input fingerprint).
+  artifacts — and, like style documents, they are OUTSIDE the input
+  fingerprint: a refreshed extract or a curation change wants an
+  explicit rebuild (`tools/feed.sh build`, or clear the feed's state
+  stamps and run sync), by design.
 - **Serving.** The atlas serves; sync writes files.

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -224,8 +224,15 @@ parent-station record where the feed ships one). Stop ids are the source
 feed's own, prefix-free. A stop whose source feed has no onestop id is
 omitted; when nothing qualifies the property is absent, not empty. This
 is how a clicked station tile feature opens a stop-detail panel keyed by
-feed identity. Markers (`ftype: "marker"`) do not carry it — they share
-the station's name, and the label feature is the identity anchor.
+feed identity.
+
+Markers (`ftype: "marker"`) carry the same `gtfs_ids`, and the same `osm`
+join key, as the station they belong to. A marker is that station seen one
+corridor at a time, not a different stop — and it is what a rider actually
+clicks: the dot itself, and, from the zoom where a complex's merged label
+yields to its per-corridor ones, the only feature still drawing a name.
+Without the identity on the marker those clicks open nothing, which is
+exactly what they did.
 
 By hand the map arrives via `chart --onestop <zip-basename>=<onestop>,…`;
 sync fills it from the registry's `onestop` fields automatically.

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -49,7 +49,10 @@ The work is finding the closure of "input set changed":
    sample rail-typed shapes every 30 m, bin into 60 m cells, a pair
    qualifies at ≥900 m of co-occupied run. A bbox prefilter keeps this
    cheap: only feeds whose window intersects a changed feed's window are
-   measured.
+   measured — transitively through region-scale windows, so a whole
+   member chain is measured together, but corridor-scale windows
+   (>20 deg²: Amtrak, VIA) are measured when touched without propagating
+   the frontier, or every patch would weld into a global run.
 3. **Group closure** — group membership is re-derived over the affected
    component (the union-find component containing any feed in C, measured
    with the same rules `tools/groups.py` uses). If membership, windows, or
@@ -113,8 +116,13 @@ entry in portolan.json already points its primary gtfs at
 `data/gtfs/<feedkey>.zip`, so a download lands exactly where the feed's
 build reads.
 
-(Phasing: today check ends after download-and-record — the handoff into
-the patch flow arrives with the patch executor itself.)
+(Phasing: today check ends after download-and-record, and `sync patch
+--dry-run` / `sync global --dry-run` print the real plan — measurement,
+group re-derivation, the rebuild closure, and whether the registry would
+be rewritten — without executing it. The executor that walks the plan is
+the next phase. A changed feed's zip must be on disk before planning:
+the measurement reads it, and a patch planned over an absent zip would
+read a partial data tree as the railway vanishing.)
 
 ## Machine-readable result
 

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -129,6 +129,21 @@ Barrelman parses this line; everything above it is human progress output.
 A build failure for one feed does not abort the run — it lands in `errors`
 and the exit code is 1, with everything else completed.
 
+## Tile contract additions
+
+Station label features (`ftype: "station"`) carry a `gtfs_ids` property:
+semicolon-joined `<feed-onestop>:<stop_id>` pairs, deduped and sorted —
+the GTFS stops merged into that station (served platforms plus the
+parent-station record where the feed ships one). Stop ids are the source
+feed's own, prefix-free. A stop whose source feed has no onestop id is
+omitted; when nothing qualifies the property is absent, not empty. This
+is how a clicked station tile feature opens a stop-detail panel keyed by
+feed identity. Markers (`ftype: "marker"`) do not carry it — they share
+the station's name, and the label feature is the identity anchor.
+
+By hand the map arrives via `chart --onestop <zip-basename>=<onestop>,…`;
+sync fills it from the registry's `onestop` fields automatically.
+
 ## What sync does not do
 
 - **Onboarding.** New feeds (Overpass extracts, pfaedle, discovery sweeps)

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -183,7 +183,9 @@ The executor walks a Plan in this order:
 
 `sync global` is the same executor with C = every feed whose zip is on
 disk. Registry entries whose zip was never downloaded (most of the
-registry is discovery output) are reported in `skipped`, not failed.
+registry is discovery output) are reported in `skipped`, not failed —
+and a derived group whose member zips are absent is out of scope, not
+unsupported: absence of data must never read as the railway vanishing.
 Sound scoring (`portolan sound`) is not part of sync — it is advisory
 and feed.sh territory.
 

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -97,12 +97,24 @@ is written after each feed completes, so a rerun resumes where it stopped.
 ## check
 
 For every feed entry with an `onestop` id, ask transitland for the current
-`feed_state.feed_version.sha1` (batched, `feeds/{onestop}`), diff against the
-manifest, download changed feeds into `--data` (via
-`download_latest_feed_version`, falling back to `urls.static_current`), then
-run the patch flow on the changed set. `--dry-run` stops after the diff.
-Feeds without an `onestop` id are reported and skipped. Exit 0 with
-`"changed": []` when nothing moved.
+`feed_state.feed_version.sha1` (one `feeds/{onestop}` request per feed,
+sequential, honoring a 429 once via Retry-After — the API has no batch
+lookup), diff against the manifest, download changed feeds into `--data` as
+`<feedkey>.zip` (via `download_latest_feed_version`, falling back to
+`urls.static_current`), then run the patch flow on the changed set. A new
+sha over identical content records the sha and changes nothing on disk.
+`--dry-run` stops after the diff, touching neither `--data` nor the
+manifest. Feeds without an `onestop` id are reported and skipped. Exit 0
+with `"changed": []` when nothing moved; check's RESULT line carries
+`{"changed":[…],"skipped":[…],"errors":[…]}`.
+
+The `<feedkey>.zip` name is not a new convention: every onestop-bearing
+entry in portolan.json already points its primary gtfs at
+`data/gtfs/<feedkey>.zip`, so a download lands exactly where the feed's
+build reads.
+
+(Phasing: today check ends after download-and-record — the handoff into
+the patch flow arrives with the patch executor itself.)
 
 ## Machine-readable result
 

--- a/internal/atlas/activity.go
+++ b/internal/atlas/activity.go
@@ -31,7 +31,7 @@ func (s *Server) activityAPI(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{"available": false})
 		return
 	}
-	st, err := os.Stat(fc.primaryGTFS())
+	st, err := os.Stat(fc.PrimaryGTFS())
 	if err != nil {
 		json.NewEncoder(w).Encode(map[string]any{"available": false, "error": err.Error()})
 		return

--- a/internal/atlas/atlas.go
+++ b/internal/atlas/atlas.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/alexwohlbruck/portolan/internal/gtfs"
 	"github.com/alexwohlbruck/portolan/internal/pipeline"
+	"github.com/alexwohlbruck/portolan/internal/registry"
 	"github.com/alexwohlbruck/portolan/internal/sketch"
 	"github.com/alexwohlbruck/portolan/internal/style"
 )
@@ -36,41 +37,12 @@ var mapHTML []byte
 //go:embed nav.js
 var navJS []byte
 
-// FeedCfg is one feed (or feed group) in portolan.json.
-type FeedCfg struct {
-	Name    string    `json:"name"`
-	GTFS    string    `json:"gtfs"` // comma list: primary feed, then overlays (Metra, Amtrak)
-	Rail    string    `json:"rail"`
-	Streets string    `json:"streets"` // optional street extract — enables bus routes
-	Stops   string    `json:"stops"`   // optional OSM stop extract — station name/id matching
-	Out     string    `json:"out"`
-	Network string    `json:"network"` // drawn ground truth for scoring
-	BBox    []float64 `json:"bbox"`    // [w,s,e,n] Overpass window + shape clip
-	// Members marks a GROUP: the feed keys whose networks this entry
-	// builds together (so cross-feed routes bundle on shared track). The
-	// group's tileset REPLACES its members' in the global index — a
-	// member listed here is skipped there, or the world would draw the
-	// same railroad twice.
-	Members []string `json:"members,omitempty"`
-}
-
-// primaryGTFS: the first feed of the comma list — scenarios and mtime
-// checks are primary-feed concepts.
-func (f FeedCfg) primaryGTFS() string {
-	if i := strings.IndexByte(f.GTFS, ','); i >= 0 {
-		return strings.TrimSpace(f.GTFS[:i])
-	}
-	return strings.TrimSpace(f.GTFS)
-}
-
-type Config struct {
-	Feeds    map[string]FeedCfg `json:"feeds"`
-	Sketches string             `json:"sketches"`
-	// StyleDir: where the curation documents live (default "style").
-	// Colours and names are NOT in this file — they are source code, one
-	// document per city, so they diff and revert on their own.
-	StyleDir string `json:"style_dir,omitempty"`
-}
+// FeedCfg and Config live in internal/registry now, shared with sync —
+// one parser for portolan.json. The aliases keep this package's API.
+type (
+	FeedCfg = registry.FeedCfg
+	Config  = registry.Config
+)
 
 // styleFor resolves the effective style for one city through the SAME
 // loader the CLI uses — style/_default.json then style/<city>.json. One
@@ -155,16 +127,7 @@ func NewServer(configPath, maplibreDir string) (*Server, error) {
 	return s, nil
 }
 
-func parseConfig(raw []byte) (Config, error) {
-	var cfg Config
-	if err := json.Unmarshal(raw, &cfg); err != nil {
-		return cfg, err
-	}
-	if cfg.Sketches == "" {
-		cfg.Sketches = "sketches"
-	}
-	return cfg, nil
-}
+func parseConfig(raw []byte) (Config, error) { return registry.Parse(raw) }
 
 // config re-reads portolan.json when it has changed on disk, so adding a
 // city (docs/CITIES.md) shows up on refresh — the same edit-and-refresh
@@ -691,7 +654,7 @@ func (s *Server) scenariosAPI(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{"available": false})
 		return
 	}
-	st, err := os.Stat(fc.primaryGTFS())
+	st, err := os.Stat(fc.PrimaryGTFS())
 	if err != nil {
 		json.NewEncoder(w).Encode(map[string]any{"available": false, "error": err.Error()})
 		return

--- a/internal/atlas/atlas.go
+++ b/internal/atlas/atlas.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -26,6 +25,7 @@ import (
 	"github.com/alexwohlbruck/portolan/internal/registry"
 	"github.com/alexwohlbruck/portolan/internal/sketch"
 	"github.com/alexwohlbruck/portolan/internal/style"
+	"github.com/alexwohlbruck/portolan/internal/tiles"
 )
 
 //go:embed editor.html
@@ -279,46 +279,14 @@ func (s *Server) Handler() http.Handler {
 	// the probe that tells it to fall back to the GeoJSON band protocol.
 	mux.HandleFunc("/api/tiles/", func(w http.ResponseWriter, r *http.Request) {
 		// index.json is the world: every feed with a cut pyramid, with its
-		// bounds — the global view draws exactly this list and nothing else
+		// bounds — the global view draws exactly this list and nothing
+		// else. Composed by tiles.Index, the SAME helper sync uses to
+		// write the static --tiles/index.json, so the two cannot drift.
 		if r.URL.Path == "/api/tiles/index.json" {
-			type entry struct {
-				Feed    string    `json:"feed"`
-				Name    string    `json:"name"`
-				Bounds  []float64 `json:"bounds,omitempty"`
-				MaxZoom int       `json:"maxzoom"`
-			}
 			cfg := s.config()
-			// a feed that rides inside a group is drawn BY the group —
-			// listing both would double-draw its railroad
-			grouped := map[string]bool{}
-			for _, fc := range cfg.Feeds {
-				for _, m := range fc.Members {
-					grouped[m] = true
-				}
-			}
-			keys := make([]string, 0, len(cfg.Feeds))
-			for k := range cfg.Feeds {
-				if !grouped[k] {
-					keys = append(keys, k)
-				}
-			}
-			sort.Strings(keys)
-			out := []entry{}
-			for _, k := range keys {
-				fc := cfg.Feeds[k]
-				raw, err := os.ReadFile(filepath.Join(filepath.Dir(fc.Out), "tiles", k, "tiles.json"))
-				if err != nil {
-					continue
-				}
-				var tj struct {
-					Bounds  []float64 `json:"bounds"`
-					MaxZoom int       `json:"maxzoom"`
-				}
-				if json.Unmarshal(raw, &tj) != nil {
-					continue
-				}
-				out = append(out, entry{Feed: k, Name: fc.Name, Bounds: tj.Bounds, MaxZoom: tj.MaxZoom})
-			}
+			out := tiles.Index(cfg, func(k string) string {
+				return filepath.Join(filepath.Dir(cfg.Feeds[k].Out), "tiles", k)
+			})
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Cache-Control", "no-store")
 			json.NewEncoder(w).Encode(out)

--- a/internal/gtfs/shapes.go
+++ b/internal/gtfs/shapes.go
@@ -1,0 +1,170 @@
+package gtfs
+
+// RailShapes — the raw shape polylines of a feed's rail-typed routes,
+// exactly as tools/groups.py reads them. This is the measurement input
+// for cross-feed grouping (internal/sync/groups.go), and it deliberately
+// bypasses Load's pattern machinery: no coverage pruning, no terminal
+// trimming, no loop excision. Grouping asks where the feed's trains RUN,
+// and every published shape answers that; the drawing pipeline's
+// clean-ups would change the measurement.
+//
+// Parity notes (the Python original is the contract):
+//   - route_type matches railTypes as a STRING — an absent or empty
+//     route_type is not rail, where Load's Atoi would read it as 0.
+//   - rows shorter than the header are skipped whole, like csv.DictReader
+//     fed through groups.py's rows().
+//   - a malformed number in shapes.txt is an ERROR — groups.py raises and
+//     the caller skips the feed as unreadable, so we do too.
+//   - one deviation: member files resolve through feedFiles, which also
+//     finds tables zipped under a folder ("gtfs/routes.txt"). groups.py
+//     checks top-level names only and would return nothing for such a
+//     feed; being tolerant here is strictly more correct.
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/alexwohlbruck/portolan/internal/geo"
+)
+
+// RailShapes returns each rail-typed shape's ordered points, in
+// first-seen shapes.txt order. railTypes holds route_type strings
+// ("2", "109", …). A feed missing routes/trips/shapes, or with no rail
+// routes, returns nil, nil.
+func RailShapes(path string, railTypes map[string]bool) ([][]geo.LL, error) {
+	files, closeFeed, err := feedFiles(path)
+	if err != nil {
+		return nil, err
+	}
+	defer closeFeed()
+	for _, n := range []string{"routes.txt", "trips.txt", "shapes.txt"} {
+		if _, ok := files[n]; !ok {
+			return nil, nil
+		}
+	}
+
+	rail := map[string]bool{}
+	if err := eachRowStrict(files["routes.txt"], func(get func(string) string) error {
+		if railTypes[get("route_type")] {
+			rail[get("route_id")] = true
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("%s: routes.txt: %w", path, err)
+	}
+	if len(rail) == 0 {
+		return nil, nil
+	}
+	shapes := map[string]bool{}
+	if err := eachRowStrict(files["trips.txt"], func(get func(string) string) error {
+		if rail[get("route_id")] && get("shape_id") != "" {
+			shapes[get("shape_id")] = true
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("%s: trips.txt: %w", path, err)
+	}
+	if len(shapes) == 0 {
+		return nil, nil
+	}
+
+	type spt struct {
+		seq, lon, lat float64
+	}
+	by := map[string][]spt{}
+	var order []string
+	if err := eachRowStrict(files["shapes.txt"], func(get func(string) string) error {
+		id := get("shape_id")
+		if !shapes[id] {
+			return nil
+		}
+		seq, e1 := strconv.ParseFloat(get("shape_pt_sequence"), 64)
+		lon, e2 := strconv.ParseFloat(get("shape_pt_lon"), 64)
+		lat, e3 := strconv.ParseFloat(get("shape_pt_lat"), 64)
+		if e1 != nil || e2 != nil || e3 != nil {
+			return fmt.Errorf("bad shape point for %s", id)
+		}
+		if _, ok := by[id]; !ok {
+			order = append(order, id)
+		}
+		by[id] = append(by[id], spt{seq, lon, lat})
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("%s: shapes.txt: %w", path, err)
+	}
+
+	out := make([][]geo.LL, 0, len(order))
+	for _, id := range order {
+		pts := by[id]
+		// (seq, lon, lat) tuple sort, exactly like Python's pts.sort()
+		sort.Slice(pts, func(i, j int) bool {
+			if pts[i].seq != pts[j].seq {
+				return pts[i].seq < pts[j].seq
+			}
+			if pts[i].lon != pts[j].lon {
+				return pts[i].lon < pts[j].lon
+			}
+			return pts[i].lat < pts[j].lat
+		})
+		poly := make([]geo.LL, len(pts))
+		for i, p := range pts {
+			poly[i] = geo.LL{Lon: p.lon, Lat: p.lat}
+		}
+		out = append(out, poly)
+	}
+	return out, nil
+}
+
+// eachRowStrict streams a CSV member with groups.py's row semantics:
+// header cells stripped, rows shorter than the header skipped whole,
+// every value stripped, duplicate header names resolved last-wins (like
+// dict(zip(head, row))). fn may return an error to abort the file.
+func eachRowStrict(open opener, fn func(get func(string) string) error) error {
+	rc, err := open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	r := csv.NewReader(rc)
+	r.FieldsPerRecord = -1
+	r.LazyQuotes = true
+	header, err := r.Read()
+	if err == io.EOF {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(header) > 0 && len(header[0]) > 2 && header[0][0] == 0xEF {
+		header[0] = header[0][3:]
+	}
+	idx := map[string]int{}
+	for i, h := range header {
+		idx[strings.TrimSpace(h)] = i
+	}
+	for {
+		row, err := r.Read()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if len(row) < len(header) {
+			continue // blank or truncated line
+		}
+		if err := fn(func(col string) string {
+			i, ok := idx[col]
+			if !ok || i >= len(row) {
+				return ""
+			}
+			return strings.TrimSpace(row[i])
+		}); err != nil {
+			return err
+		}
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -908,11 +908,44 @@ func WriteSegmentsGeoJSON(path string, segs []stages.Segment, frame geo.Frame) e
 		}, s.Line, frame); ok {
 			if len(s.Acts) > 0 {
 				f.Props["acts"] = strings.Join(s.Acts, ";")
+				if idx := actsIndex(s.Routes, len(s.Acts)); idx != "" {
+					f.Props["ridx"] = idx
+				}
 			}
 			fc.Features = append(fc.Features, f)
 		}
 	}
 	return writeFC(path, fc)
+}
+
+// actsIndex names each route's slot in the `acts` string: "A=00;C=01;E=02".
+//
+// `acts` is aligned to `routes` and every mask is the same width, so slot
+// i starts at a fixed stride — a consumer that knows i can read one route's
+// mask exactly. What it cannot do is FIND i: a filter expression can slice
+// a string at a computed offset but cannot count the commas before a token,
+// and route ids are not fixed width. So the index is published instead of
+// re-derived, two digits per route, which is a fifth of what repeating the
+// masks per route would cost.
+//
+// Two digits is enough by construction: ACTS_MAX_ROUTES is 16, and a
+// segment carrying more masks than routes (or fewer) is not indexable at
+// all — better to omit the field than to name a slot that is not there.
+func actsIndex(routes []string, masks int) string {
+	if len(routes) != masks || len(routes) > 99 {
+		return ""
+	}
+	var b strings.Builder
+	for i, r := range routes {
+		if r == "" || strings.ContainsAny(r, ";=") {
+			return "" // a delimiter inside an id would break every lookup
+		}
+		if i > 0 {
+			b.WriteByte(';')
+		}
+		fmt.Fprintf(&b, "%s=%02d", r, i)
+	}
+	return b.String()
 }
 
 // vertexFeature emits a line's own vertices (no resampling).

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -183,6 +184,12 @@ type ChartOpts struct {
 	// the extract, not to ship the chord. The escape hatch exists for
 	// extracts known to be incomplete mid-migration.
 	AllowUnmatched bool
+	// Onestop: transitland onestop id per source GTFS zip, keyed by the
+	// zip's basename without ".zip" ("mta-subway" for data/gtfs/
+	// mta-subway.zip). Optional; feeds absent here simply contribute no
+	// gtfs_ids entries. The chart CLI fills it from --onestop; sync
+	// (phase 3) fills it from the registry's onestop fields.
+	Onestop map[string]string
 	// ExportGTFS: a directory to write ADJUSTED copies of the source
 	// feeds into — each input zip again, with shapes.txt geometry
 	// replaced by the matched track walk (export.go). Path-only like
@@ -614,7 +621,8 @@ func layout(in layoutIn, logf func(string, ...any)) error {
 	} else {
 		logf("caterpillars: off (style)")
 	}
-	if err := writeStations(o.Out+".stations.geojson", sts, cats); err != nil {
+	if err := writeStations(o.Out+".stations.geojson", sts, cats,
+		onestopByPrefix(o.GTFS, o.Onestop)); err != nil {
 		return err
 	}
 	// the resolved style travels WITH the build: the viewer renders widths,
@@ -987,6 +995,34 @@ func LoadServiceInfo(gtfsPaths string) (*gtfs.ServiceInfo, error) {
 			return c.Drawable() && c != mode.Bus
 		},
 	})
+}
+
+// onestopByPrefix resolves ChartOpts.Onestop (keyed by zip basename)
+// into the feed prefixes loadFeeds stamps on ids: "" for the primary,
+// "f1", "f2"… for overlays, in comma-list order — the SAME order
+// loadFeeds numbers them, so the two cannot disagree about which feed
+// "f1" is. Nil in, nil out.
+func onestopByPrefix(gtfsPaths string, byKey map[string]string) map[string]string {
+	if len(byKey) == 0 || gtfsPaths == "" {
+		return nil
+	}
+	out := map[string]string{}
+	for i, p := range strings.Split(gtfsPaths, ",") {
+		key := strings.TrimSuffix(filepath.Base(strings.TrimSpace(p)), ".zip")
+		os, ok := byKey[key]
+		if !ok || os == "" {
+			continue
+		}
+		if i == 0 {
+			out[""] = os
+		} else {
+			out[fmt.Sprintf("f%d", i)] = os
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // loadFeeds loads and merges every feed in the comma list. Overlay route

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,0 +1,36 @@
+package pipeline
+
+import "testing"
+
+// A filter expression can slice `acts` at a computed offset but cannot
+// count commas, so the tile has to say which slot each route owns.
+func TestActsIndex(t *testing.T) {
+	if got := actsIndex([]string{"A", "C", "E"}, 3); got != "A=00;C=01;E=02" {
+		t.Fatalf("actsIndex = %q", got)
+	}
+	// ids are the feed's own and can be long, or carry an overlay prefix
+	if got := actsIndex([]string{"B_CMX0700L1", "f1:237"}, 2); got != "B_CMX0700L1=00;f1:237=01" {
+		t.Fatalf("actsIndex long = %q", got)
+	}
+	// misalignment is not indexable: naming a slot that is not there would
+	// have a consumer read another route's hours as this one's
+	for _, tc := range []struct {
+		routes []string
+		masks  int
+	}{
+		{[]string{"A", "C"}, 3},
+		{[]string{"A", "C"}, 1},
+		{nil, 0},
+	} {
+		if got := actsIndex(tc.routes, tc.masks); got != "" {
+			t.Errorf("actsIndex(%v, %d) = %q, want empty", tc.routes, tc.masks, got)
+		}
+	}
+	// a delimiter inside an id would break every lookup built on it
+	if got := actsIndex([]string{"A;B"}, 1); got != "" {
+		t.Errorf("actsIndex with a semicolon = %q, want empty", got)
+	}
+	if got := actsIndex([]string{"A=B"}, 1); got != "" {
+		t.Errorf("actsIndex with an equals = %q, want empty", got)
+	}
+}

--- a/internal/pipeline/stations.go
+++ b/internal/pipeline/stations.go
@@ -69,6 +69,14 @@ type Station struct {
 	// join a drawn station back to OpenStreetMap (docs/STOP-LABELS.md).
 	OSMID string
 
+	// StopIDs: every GTFS stop merged into this station — platforms and
+	// parent-station records, still carrying loadFeeds' overlay prefix
+	// ("f1:GCT"). Sorted and deduped. This is the identity the gtfs_ids
+	// tile prop is assembled from, so a clicked station can open a
+	// stop-detail panel keyed by the source feed's own ids (docs/SYNC.md,
+	// "Tile contract additions").
+	StopIDs []string
+
 	// Set by SnapStations: where the label anchors (the busiest marker),
 	// and one marker per ribbon bundle the station's lines snap to — a
 	// complex like Times Sq is one label but three bundles, each with its
@@ -489,6 +497,25 @@ func BuildStations(feed *gtfs.Feed, pats []gtfs.Pattern, bbox []float64,
 		sortBullets(rids, routeByID)
 
 		st := Station{Name: name, LL: geo.LL{Lon: cx / float64(np), Lat: cy / float64(np)}}
+		{
+			// member stop identity: the served platforms, plus the parent
+			// station record when the feed ships one (it is a stops.txt row
+			// too, and the id a downstream API most likely keys on)
+			ids := map[string]bool{}
+			for _, ni := range members {
+				for _, sid := range nodes[ni].g.stops {
+					ids[sid] = true
+				}
+				if _, ok := feed.Stops[nodes[ni].g.key]; ok {
+					ids[nodes[ni].g.key] = true
+				}
+			}
+			st.StopIDs = make([]string, 0, len(ids))
+			for sid := range ids {
+				st.StopIDs = append(st.StopIDs, sid)
+			}
+			sort.Strings(st.StopIDs)
+		}
 		{
 			out := map[string]bool{}
 			inside := map[string]bool{}
@@ -1106,12 +1133,45 @@ func naturalCmp(a, b string) int {
 	return strings.Compare(a, b)
 }
 
+// gtfsIDProp assembles a station's gtfs_ids tile prop from its member
+// stop ids: semicolon-joined "<feed-onestop>:<stop_id>" pairs, deduped
+// and sorted. onestop maps loadFeeds' feed prefix ("" primary, "f1"…)
+// to that feed's onestop id; a stop whose source feed has no onestop id
+// is omitted — an absent pair is an honest "not registered", not an
+// empty key. Empty result means the prop is omitted entirely.
+func gtfsIDProp(stopIDs []string, onestop map[string]string) string {
+	if len(onestop) == 0 {
+		return ""
+	}
+	seen := map[string]bool{}
+	var pairs []string
+	for _, sid := range stopIDs {
+		pre := feedPrefix(sid)
+		os, ok := onestop[pre]
+		if !ok || os == "" {
+			continue
+		}
+		bare := sid
+		if pre != "" {
+			bare = sid[len(pre)+1:] // strip "fN:"
+		}
+		p := os + ":" + bare
+		if !seen[p] {
+			seen[p] = true
+			pairs = append(pairs, p)
+		}
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ";")
+}
+
 // writeStations emits <out>.stations.geojson: one `ftype: "station"`
 // label feature per station (anchored at its busiest marker) plus one
 // `ftype: "marker"` feature per snapped bundle — a complex is one label
 // and as many markers as corridors. Aligned per-route arrays are
-// comma-joined like ribbon `routes`.
-func writeStations(path string, sts []Station, cats []CatBullet) error {
+// comma-joined like ribbon `routes`. onestop (feed prefix → onestop id,
+// nil ok) adds the gtfs_ids identity prop to station features.
+func writeStations(path string, sts []Station, cats []CatBullet, onestop map[string]string) error {
 	fc := collection{Type: "FeatureCollection"}
 	pt := func(ll geo.LL) json.RawMessage {
 		raw, _ := json.Marshal([2]float64{ll.Lon, ll.Lat})
@@ -1145,6 +1205,11 @@ func writeStations(path string, sts []Station, cats []CatBullet) error {
 		// stand behind — an absent key is an honest "not matched"
 		if s.OSMID != "" {
 			stProps["osm"] = s.OSMID
+		}
+		// GTFS stop identity for downstream stop-detail panels — omitted
+		// when no source feed has an onestop id (docs/SYNC.md)
+		if ids := gtfsIDProp(s.StopIDs, onestop); ids != "" {
+			stProps["gtfs_ids"] = ids
 		}
 		fc.Features = append(fc.Features, feature{
 			Type: "Feature", Props: stProps,

--- a/internal/pipeline/stations.go
+++ b/internal/pipeline/stations.go
@@ -1170,7 +1170,10 @@ func gtfsIDProp(stopIDs []string, onestop map[string]string) string {
 // `ftype: "marker"` feature per snapped bundle — a complex is one label
 // and as many markers as corridors. Aligned per-route arrays are
 // comma-joined like ribbon `routes`. onestop (feed prefix → onestop id,
-// nil ok) adds the gtfs_ids identity prop to station features.
+// nil ok) adds the gtfs_ids identity prop; it and the OSM join key go on
+// the station AND on every one of its markers, which are that same
+// station seen one corridor at a time — and, at high zoom over a complex,
+// the only features still carrying a label.
 func writeStations(path string, sts []Station, cats []CatBullet, onestop map[string]string) error {
 	fc := collection{Type: "FeatureCollection"}
 	pt := func(ll geo.LL) json.RawMessage {
@@ -1208,8 +1211,9 @@ func writeStations(path string, sts []Station, cats []CatBullet, onestop map[str
 		}
 		// GTFS stop identity for downstream stop-detail panels — omitted
 		// when no source feed has an onestop id (docs/SYNC.md)
-		if ids := gtfsIDProp(s.StopIDs, onestop); ids != "" {
-			stProps["gtfs_ids"] = ids
+		gtfsIDs := gtfsIDProp(s.StopIDs, onestop)
+		if gtfsIDs != "" {
+			stProps["gtfs_ids"] = gtfsIDs
 		}
 		fc.Features = append(fc.Features, feature{
 			Type: "Feature", Props: stProps,
@@ -1230,6 +1234,20 @@ func writeStations(path string, sts []Station, cats []CatBullet, onestop map[str
 				"rank":         len(s.Routes),
 				"imp":          s.Imp,
 				"nmarkers":     len(s.Markers),
+			}
+			// A marker carries the STATION's identity, because it is that
+			// station: the dot a rider clicks, and — at high zoom over a
+			// complex, where the merged label bows out for the
+			// per-corridor ones — the only labelled feature left. Without
+			// these the click has nothing to open, so Fulton St answered
+			// a click and Times Sq did not. Same values, not a subset:
+			// a marker is one corridor of the station, not a different
+			// stop, and the station's ids are what identify it.
+			if s.OSMID != "" {
+				props["osm"] = s.OSMID
+			}
+			if gtfsIDs != "" {
+				props["gtfs_ids"] = gtfsIDs
 			}
 			if m.Pill {
 				props["span_px"] = math.Round(m.SpanPx*10) / 10

--- a/internal/pipeline/stations_test.go
+++ b/internal/pipeline/stations_test.go
@@ -1,7 +1,10 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"math"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -456,5 +459,87 @@ func TestOnestopByPrefix(t *testing.T) {
 	}
 	if onestopByPrefix("a.zip", map[string]string{"b": "f-b"}) != nil {
 		t.Fatal("no key matched: nil, not empty pairs")
+	}
+}
+
+// A marker is the station, one corridor at a time — the dot a rider
+// clicks, and at high zoom over a complex the only labelled feature left
+// once the merged label bows out. So it has to carry the same identity
+// the station does, or those clicks open nothing.
+func TestMarkersCarryStationIdentity(t *testing.T) {
+	sts := []Station{{
+		Name:    "Fulton St",
+		LL:      geo.LL{Lat: 40.7101, Lon: -74.0090},
+		LabelLL: geo.LL{Lat: 40.7101, Lon: -74.0090},
+		OSMID:   "node/1683730419",
+		StopIDs: []string{"418", "635"},
+		Routes:  []string{"A", "4"},
+		Markers: []Marker{
+			{LL: geo.LL{Lat: 40.7101, Lon: -74.0090}, Routes: []string{"A"}},
+			{LL: geo.LL{Lat: 40.7104, Lon: -74.0088}, Routes: []string{"4"}},
+		},
+	}}
+	dir := t.TempDir()
+	out := filepath.Join(dir, "fulton")
+	if err := writeStations(out+".stations.geojson", sts, nil, map[string]string{"": "f-dr5r-nyctsubway"}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(out + ".stations.geojson")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fc struct {
+		Features []struct {
+			Props map[string]any `json:"properties"`
+		} `json:"features"`
+	}
+	if err := json.Unmarshal(raw, &fc); err != nil {
+		t.Fatal(err)
+	}
+
+	const wantIDs = "f-dr5r-nyctsubway:418;f-dr5r-nyctsubway:635"
+	markers := 0
+	for _, f := range fc.Features {
+		switch f.Props["ftype"] {
+		case "station", "marker":
+			if f.Props["ftype"] == "marker" {
+				markers++
+			}
+			if got := f.Props["osm"]; got != "node/1683730419" {
+				t.Errorf("%v osm = %v", f.Props["ftype"], got)
+			}
+			if got := f.Props["gtfs_ids"]; got != wantIDs {
+				t.Errorf("%v gtfs_ids = %v", f.Props["ftype"], got)
+			}
+		}
+	}
+	if markers != 2 {
+		t.Fatalf("markers = %d, want 2", markers)
+	}
+
+	// an unmatched station emits neither key rather than an empty one:
+	// absence is the honest "not matched", and "" would read as an id
+	sts[0].OSMID = ""
+	if err := writeStations(out+".none.geojson", sts, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ = os.ReadFile(out + ".none.geojson")
+	// a FRESH value: unmarshalling into the old one merges into the maps
+	// it already holds, and every key would still be there
+	var bare struct {
+		Features []struct {
+			Props map[string]any `json:"properties"`
+		} `json:"features"`
+	}
+	if err := json.Unmarshal(raw, &bare); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range bare.Features {
+		if _, ok := f.Props["osm"]; ok {
+			t.Error("osm emitted for an unmatched station")
+		}
+		if _, ok := f.Props["gtfs_ids"]; ok {
+			t.Error("gtfs_ids emitted with no onestop map")
+		}
 	}
 }

--- a/internal/pipeline/stations_test.go
+++ b/internal/pipeline/stations_test.go
@@ -398,3 +398,63 @@ func TestNormName(t *testing.T) {
 		t.Fatal("abbreviations must NOT expand")
 	}
 }
+
+func TestStationStopIDsAndGTFSIDProp(t *testing.T) {
+	feed, pats := testFeed()
+	sts := BuildStations(feed, pats, nil, nil)
+	var gc *Station
+	for i := range sts {
+		if sts[i].Name == "Grand Central" {
+			gc = &sts[i]
+		}
+	}
+	if gc == nil {
+		t.Fatal("no Grand Central")
+	}
+	// the served platforms, the parent record (a stops.txt row itself),
+	// and the overlay feed's stop — sorted, still prefixed
+	want := []string{"GC", "GCn", "GCs", "f1:GCT"}
+	if !reflect.DeepEqual(gc.StopIDs, want) {
+		t.Fatalf("GC StopIDs = %v, want %v", gc.StopIDs, want)
+	}
+
+	// both feeds registered: pairs from both, prefixes stripped, sorted
+	m := map[string]string{"": "f-dr5r-nyct", "f1": "f-mnr"}
+	got := gtfsIDProp(gc.StopIDs, m)
+	if got != "f-dr5r-nyct:GC;f-dr5r-nyct:GCn;f-dr5r-nyct:GCs;f-mnr:GCT" {
+		t.Fatalf("gtfs_ids = %q", got)
+	}
+	// overlay feed unregistered: its stop is omitted, not emitted bare
+	got = gtfsIDProp(gc.StopIDs, map[string]string{"": "f-dr5r-nyct"})
+	if got != "f-dr5r-nyct:GC;f-dr5r-nyct:GCn;f-dr5r-nyct:GCs" {
+		t.Fatalf("gtfs_ids sans overlay = %q", got)
+	}
+	// only the overlay registered: primary stops omitted
+	got = gtfsIDProp(gc.StopIDs, map[string]string{"f1": "f-mnr"})
+	if got != "f-mnr:GCT" {
+		t.Fatalf("gtfs_ids overlay-only = %q", got)
+	}
+	// no map at all: prop absent
+	if got := gtfsIDProp(gc.StopIDs, nil); got != "" {
+		t.Fatalf("gtfs_ids with no onestop map = %q, want empty", got)
+	}
+	// duplicate ids collapse
+	if got := gtfsIDProp([]string{"A", "A"}, map[string]string{"": "f-x"}); got != "f-x:A" {
+		t.Fatalf("dedup: %q", got)
+	}
+}
+
+func TestOnestopByPrefix(t *testing.T) {
+	m := onestopByPrefix("data/gtfs/mta-subway.zip, data/gtfs/mnr.zip,amtrak.zip",
+		map[string]string{"mta-subway": "f-nyct", "amtrak": "f-amtk"})
+	want := map[string]string{"": "f-nyct", "f2": "f-amtk"}
+	if !reflect.DeepEqual(m, want) {
+		t.Fatalf("onestopByPrefix = %v, want %v", m, want)
+	}
+	if onestopByPrefix("a.zip", nil) != nil {
+		t.Fatal("nil map must stay nil")
+	}
+	if onestopByPrefix("a.zip", map[string]string{"b": "f-b"}) != nil {
+		t.Fatal("no key matched: nil, not empty pairs")
+	}
+}

--- a/internal/pipeline/zz_lmask_test.go
+++ b/internal/pipeline/zz_lmask_test.go
@@ -1,0 +1,33 @@
+package pipeline
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+func TestDumpLMasks(t *testing.T) {
+	group := "/home/alex/Documents/code/portolan/data/gtfs/hartford-line.zip,/home/alex/Documents/code/portolan/data/gtfs/mta-lirr.zip,/home/alex/Documents/code/portolan/data/gtfs/mta-metro-north.zip,/home/alex/Documents/code/portolan/data/gtfs/mta-subway.zip,/home/alex/Documents/code/portolan/data/gtfs/nj-transit-rail.zip,/home/alex/Documents/code/portolan/data/gtfs/patco.zip,/home/alex/Documents/code/portolan/data/gtfs/path.zip,/home/alex/Documents/code/portolan/data/gtfs/rioc-nyc.zip,/home/alex/Documents/code/portolan/data/gtfs/septa-rail.zip,/home/alex/Documents/code/portolan/data/gtfs/amtrak.zip,/home/alex/Documents/code/portolan/data/gtfs/viarail.zip"
+	for _, tc := range []struct{ name, paths, route string }{
+		{"member", "/home/alex/Documents/code/portolan/data/gtfs/mta-subway.zip", "L"},
+		{"group", group, "f3:L"},
+	} {
+		si, err := LoadServiceInfo(tc.paths)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		pm := si.PatternMasks()
+		var lines []string
+		for k, m := range pm {
+			if k.Route != tc.route {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("   shape=%-24s mask=%s", k.Shape, m.Hex()))
+		}
+		sort.Strings(lines)
+		fmt.Printf("%s: %d L patterns\n", tc.name, len(lines))
+		for _, l := range lines {
+			fmt.Println(l)
+		}
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -20,6 +20,13 @@ type FeedCfg struct {
 	Out     string    `json:"out"`
 	Network string    `json:"network"` // drawn ground truth for scoring
 	BBox    []float64 `json:"bbox"`    // [w,s,e,n] Overpass window + shape clip
+	// Corridors: an authored corridor graph — the alternative geometry
+	// source to Rail (docs/CORRIDORS.md); the build passes --corridors
+	// instead of --rail when set.
+	Corridors string `json:"corridors,omitempty"`
+	// StreetsFrom: member street extracts a GROUP merges into Streets
+	// before building (tools/groupbuild.sh; sync does the same merge).
+	StreetsFrom []string `json:"streets_from,omitempty"`
 	// Members marks a GROUP: the feed keys whose networks this entry
 	// builds together (so cross-feed routes bundle on shared track). The
 	// group's tileset REPLACES its members' in the global index — a

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,80 @@
+// Package registry reads portolan.json, the feed registry: one entry per
+// feed (or feed group), naming its inputs and its window. The atlas serves
+// from it, sync reconciles against it — one parser, so the two cannot
+// disagree about what a feed entry means.
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+// FeedCfg is one feed (or feed group) in portolan.json.
+type FeedCfg struct {
+	Name    string    `json:"name"`
+	GTFS    string    `json:"gtfs"` // comma list: primary feed, then overlays (Metra, Amtrak)
+	Rail    string    `json:"rail"`
+	Streets string    `json:"streets"` // optional street extract — enables bus routes
+	Stops   string    `json:"stops"`   // optional OSM stop extract — station name/id matching
+	Out     string    `json:"out"`
+	Network string    `json:"network"` // drawn ground truth for scoring
+	BBox    []float64 `json:"bbox"`    // [w,s,e,n] Overpass window + shape clip
+	// Members marks a GROUP: the feed keys whose networks this entry
+	// builds together (so cross-feed routes bundle on shared track). The
+	// group's tileset REPLACES its members' in the global index — a
+	// member listed here is skipped there, or the world would draw the
+	// same railroad twice.
+	Members []string `json:"members,omitempty"`
+	// Overlays: wide feeds (Amtrak) riding through a group's window —
+	// listed in the group's gtfs but not members, so they keep their own
+	// background build with this window cut out.
+	Overlays []string `json:"overlays,omitempty"`
+	// Derived: the entry was measured into existence by tools/groups.py,
+	// not curated by hand — groups.py may rewrite or dissolve it.
+	Derived bool `json:"derived,omitempty"`
+	// ChartArgs: extra chart flags this build needs, verbatim.
+	ChartArgs string `json:"chart_args,omitempty"`
+	// Onestop: the feed's Transitland onestop id — how sync asks whether
+	// the feed changed upstream. Empty means sync skips the feed.
+	Onestop string `json:"onestop,omitempty"`
+}
+
+// PrimaryGTFS: the first feed of the comma list — scenarios and mtime
+// checks are primary-feed concepts.
+func (f FeedCfg) PrimaryGTFS() string {
+	if i := strings.IndexByte(f.GTFS, ','); i >= 0 {
+		return strings.TrimSpace(f.GTFS[:i])
+	}
+	return strings.TrimSpace(f.GTFS)
+}
+
+type Config struct {
+	Feeds    map[string]FeedCfg `json:"feeds"`
+	Sketches string             `json:"sketches"`
+	// StyleDir: where the curation documents live (default "style").
+	// Colours and names are NOT in this file — they are source code, one
+	// document per city, so they diff and revert on their own.
+	StyleDir string `json:"style_dir,omitempty"`
+}
+
+// Parse decodes a registry document and fills defaults.
+func Parse(raw []byte) (Config, error) {
+	var cfg Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return cfg, err
+	}
+	if cfg.Sketches == "" {
+		cfg.Sketches = "sketches"
+	}
+	return cfg, nil
+}
+
+// Load reads and parses a registry file.
+func Load(path string) (Config, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+	return Parse(raw)
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,43 @@
+package registry
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	raw := []byte(`{
+		"feeds": {
+			"dallas": {
+				"name": "Dallas–Fort Worth",
+				"gtfs": "data/gtfs/dart.zip,data/gtfs/amtrak.zip",
+				"rail": "build/dallas-rail.geojson",
+				"out": "build/dallas.geojson",
+				"bbox": [-97.5, 32.4, -96.4, 33.3],
+				"members": ["dart"],
+				"overlays": ["amtrak"],
+				"derived": true,
+				"chart_args": "--set match_gap_cost=150"
+			},
+			"dart": {
+				"name": "DART",
+				"gtfs": "data/gtfs/dart.zip",
+				"onestop": "f-9vg-dart"
+			}
+		}
+	}`)
+	cfg, err := Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Sketches != "sketches" {
+		t.Errorf("Sketches default = %q, want sketches", cfg.Sketches)
+	}
+	d := cfg.Feeds["dallas"]
+	if d.PrimaryGTFS() != "data/gtfs/dart.zip" {
+		t.Errorf("PrimaryGTFS = %q", d.PrimaryGTFS())
+	}
+	if len(d.Members) != 1 || len(d.Overlays) != 1 || !d.Derived || d.ChartArgs == "" {
+		t.Errorf("group fields lost: %+v", d)
+	}
+	if got := cfg.Feeds["dart"].Onestop; got != "f-9vg-dart" {
+		t.Errorf("Onestop = %q", got)
+	}
+}

--- a/internal/stages/terminal_cuts.go
+++ b/internal/stages/terminal_cuts.go
@@ -187,13 +187,30 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 							if td > tcEndDistM {
 								continue
 							}
+							// A trim may shave the overshoot beyond a
+							// terminal stop; it may never erase the ride.
+							// A path that runs the WHOLE segment puts both
+							// its tips on it, so one interior stop matches
+							// the tail test on BOTH sides and pulls a and b
+							// onto itself — a zero-length cover, which votes
+							// for no hours at all. The all-day pattern then
+							// contributes nothing to the segment's mask and
+							// the line inherits the hours of whatever
+							// short-turn variant is left: Charlotte's LYNX
+							// read as 04:00-05:00 service and vanished from
+							// a live map for the other twenty-two hours.
+							na, nb := cv.a, cv.b
 							if ta > sa && L-ta < tcMarginM {
-								cv.b = sa // tail on the high side
+								nb = sa // tail on the high side
 							} else if ta < sa && ta < tcMarginM {
-								cv.a = sa // tail on the low side
+								na = sa // tail on the low side
 							} else {
 								continue
 							}
+							if nb-na < tcEndDistM {
+								continue
+							}
+							cv.a, cv.b = na, nb
 							if sa > tcMarginM && sa < L-tcMarginM {
 								terminal = sa
 							}

--- a/internal/stages/terminal_cuts.go
+++ b/internal/stages/terminal_cuts.go
@@ -33,6 +33,9 @@ import (
 
 var tcDebug = os.Getenv("PORTOLAN_TCDBG") != ""
 
+// PORTOLAN_TCROUTE=<route id> traces every path decision for one route.
+var tcRoute = os.Getenv("PORTOLAN_TCROUTE")
+
 const (
 	tcEndDistM = 40.0  // a path endpoint this close to the segment is ON it
 	tcRideM    = 40.0  // a sample this close to a path counts as ridden
@@ -45,6 +48,34 @@ const (
 type pathCover struct {
 	a, b float64
 	mask gtfs.Mask168
+}
+
+// explains reports whether the patterns found on this segment can account
+// for every hour it already has — the precondition for rewriting them.
+//
+// This pass may only REFINE: each piece gets a subset of the segment's
+// hours, so what the pieces cover together must still be the whole. A
+// pattern that rides these edges but whose path never came near the drawn
+// centerline contributes nothing, and refining without it deletes service
+// that is really there.
+//
+// Not hypothetical. In the northeast-corridor group the L's two all-day
+// patterns produced neither cover nor contact, so the recomputation
+// replaced a 24/7 railway with the hours of its two limited-service
+// patterns, and the Canarsie line went dark on the map at night. The same
+// feed built alone was correct — the group matches against a merged rail
+// extract with --allow-unmatched, and the L's paths ended up somewhere the
+// centerline is not. Hours nothing here can explain are the signal that
+// this segment is not reconstructible, whatever the reason.
+func explains(acts []string, ri int, explained gtfs.Mask168) bool {
+	if ri >= len(acts) {
+		return true // no prior claim to contradict
+	}
+	orig, ok := gtfs.ParseMask168(acts[ri])
+	if !ok {
+		return true // nothing parseable to preserve
+	}
+	return explained.Or(orig) == explained
 }
 
 // CutSegmentsAtTerminals cuts steady/bridge segments at mid-segment
@@ -127,10 +158,18 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 		for ri, rid := range s.Routes {
 			ok := true
 			var cvs []pathCover
+			// every hour a pattern that touches this segment can account
+			// for, whether or not its coverage was usable
+			var explained gtfs.Mask168
 			for _, pi := range byRoute[rid] {
 				pa := &paths[pi]
-				cv, terminal, okc := coverOn(s.Line, L, pa.Line)
+				cv, terminal, okc, touches := coverOn(s.Line, L, pa.Line)
 				if !okc {
+					if touches {
+						if m, has := patternActs[pathActKey(*pa)]; has {
+							explained = explained.Or(m)
+						}
+					}
 					continue
 				}
 				mask, has := patternActs[pathActKey(*pa)]
@@ -138,6 +177,7 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 					ok = false
 					break
 				}
+				explained = explained.Or(mask)
 				cv.mask = mask
 				// pull the terminal back from the overshot path tip to
 				// the pattern's terminal STOP where we know it
@@ -181,8 +221,34 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 						// ending at nearer platforms must not keep the
 						// tail lit); only the CUT placement respects
 						// the sliver margin.
+						// A terminal stop trims the tail on ITS OWN side.
+						// A path that runs the whole segment puts both
+						// tips on it, and pairing a stop with the far tip
+						// reads the entire line as that stop's overshoot:
+						// the L's terminals sit 68 m and 110 m inside the
+						// drawn line (platforms, as always), and the far
+						// pairing shrank a 16 km 24/7 cover to a 68 m
+						// sliver. The line then inherited the hours of its
+						// limited-service variants and went dark at night.
+						// So when both tips are on the segment, a stop
+						// speaks only for the nearer one.
 						pp := pa.Line.Pts
+						tips := make([]geo.Pt, 0, 2)
 						for _, tip := range []geo.Pt{pp[0], pp[len(pp)-1]} {
+							if _, td := s.Line.ProjectArc(tip); td <= tcEndDistM {
+								tips = append(tips, tip)
+							}
+						}
+						if len(tips) == 2 {
+							a0, _ := s.Line.ProjectArc(tips[0])
+							a1, _ := s.Line.ProjectArc(tips[1])
+							if math.Abs(a1-sa) < math.Abs(a0-sa) {
+								tips = tips[1:]
+							} else {
+								tips = tips[:1]
+							}
+						}
+						for _, tip := range tips {
 							ta, td := s.Line.ProjectArc(tip)
 							if td > tcEndDistM {
 								continue
@@ -222,7 +288,12 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 					cuts = append(cuts, terminal)
 				}
 			}
-			if ok && len(cvs) > 0 {
+			if tcRoute != "" && rid == tcRoute {
+				for _, cv := range cvs {
+					fmt.Printf("TCFINAL seg=%d cover=[%.0f,%.0f] mask=%s\n", si, cv.a, cv.b, cv.mask.Hex()[:8])
+				}
+			}
+			if ok && len(cvs) > 0 && explains(s.Acts, ri, explained) {
 				covers[ri] = cvs
 				trusted[ri] = true
 			}
@@ -338,7 +409,15 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 // lands in the segment (or -1). A path either covers the whole segment
 // (segments end at junctions; paths only join and leave there) or a
 // prefix/suffix ending at one of its own endpoints.
-func coverOn(sl *geo.Line, L float64, path *geo.Line) (pathCover, float64, bool) {
+// coverOn projects a pattern's path onto a segment. The third result is
+// the usable cover; the fourth says the path TOUCHES this segment even
+// when no cover could be read off it — an endpoint of the path lands
+// inside, so the pattern is demonstrably here, and its hours are
+// accounted for even though its coverage is too ambiguous to refine
+// with. That distinction is what separates a tip-toucher (deliberately
+// excluded, hours explained) from a pattern whose geometry has drifted
+// away from the drawn centerline entirely (hours unexplained).
+func coverOn(sl *geo.Line, L float64, path *geo.Line) (pathCover, float64, bool, bool) {
 	// where do the path's endpoints sit relative to the segment?
 	pts := path.Pts
 	e0, e1 := pts[0], pts[len(pts)-1]
@@ -353,11 +432,11 @@ func coverOn(sl *geo.Line, L float64, path *geo.Line) (pathCover, float64, bool)
 		// path lives entirely within it (a stub pattern)
 		lo, hi := math.Min(a0, a1), math.Max(a0, a1)
 		if !ride((lo + hi) / 2) {
-			return pathCover{}, -1, false
+			return pathCover{}, -1, false, true
 		}
 		// two interior terminals: report the one further from an end —
 		// the caller's margin filters both anyway
-		return pathCover{a: lo, b: hi}, lo, true
+		return pathCover{a: lo, b: hi}, lo, true, true
 	case in0 || in1:
 		t := a0
 		if in1 {
@@ -368,19 +447,35 @@ func coverOn(sl *geo.Line, L float64, path *geo.Line) (pathCover, float64, bool)
 		const pr = tcRideM + 20
 		loSide := t > pr && ride(t-pr)
 		hiSide := t < L-pr && ride(t+pr)
-		if loSide == hiSide {
-			return pathCover{}, -1, false // ambiguous or crossing — skip
+		if loSide && hiSide {
+			// The path rides BOTH sides of its own endpoint, so that
+			// endpoint is not a terminal for this segment — the pattern
+			// runs through. It happens where a terminal stop projects a
+			// few metres inside the drawn centerline, and reading it as
+			// "ambiguous" cost the L its hours: its two all-day patterns
+			// were skipped here, leaving the segment to be rebuilt from
+			// limited-service patterns alone, and a 24/7 railway went
+			// dark at night. The ride probes are the evidence; believe
+			// them over the projection.
+			return pathCover{a: 0, b: L}, -1, true, true
+		}
+		if !loSide && !hiSide {
+			// touches without riding either side: a tip-toucher, which
+			// must not light the segment it barely reaches
+			return pathCover{}, -1, false, true
 		}
 		if loSide {
-			return pathCover{a: 0, b: t}, t, true
+			return pathCover{a: 0, b: t}, t, true, true
 		}
-		return pathCover{a: t, b: L}, t, true
+		return pathCover{a: t, b: L}, t, true, true
 	default:
-		// no endpoint inside: full coverage or none
+		// no endpoint inside: full coverage or none. "None" here means
+		// the path is not on this centerline — either it rides elsewhere
+		// entirely, or its geometry drifted off the line that was drawn.
 		if ride(L*0.5) && ride(L*0.25) && ride(L*0.75) {
-			return pathCover{a: 0, b: L}, -1, true
+			return pathCover{a: 0, b: L}, -1, true, true
 		}
-		return pathCover{}, -1, false
+		return pathCover{}, -1, false, false
 	}
 }
 

--- a/internal/stages/terminal_cuts_test.go
+++ b/internal/stages/terminal_cuts_test.go
@@ -206,3 +206,67 @@ func TestCutsPullBackToTerminalStop(t *testing.T) {
 		t.Fatalf("acts wrong: near=%s far=%s", out[0].Acts[0], out[1].Acts[0])
 	}
 }
+
+// The L problem in miniature: a segment whose 24/7 hours come from a
+// pattern that no longer rides its centerline — the geometry drifted,
+// which is what --allow-unmatched and a merged rail extract can do in a
+// group build. Recomputing from what is left would replace a railway that
+// runs all night with the hours of a limited-service pattern.
+//
+// The same feed built alone got this right, so the guard has to be
+// explicit: hours nothing on this segment can explain mean the segment is
+// not reconstructible, and the original stands.
+func TestCutsKeepHoursNoPatternCanExplain(t *testing.T) {
+	line := func(x0, x1, y float64) *geo.Line {
+		var pts []geo.Pt
+		for x := x0; x <= x1; x += 50 {
+			pts = append(pts, geo.Pt{X: x, Y: y})
+		}
+		return geo.NewLine(pts)
+	}
+	allDay := gtfs.Pattern{Route: gtfs.Route{ID: "L"}, ShapeID: "allday"}
+	rush := gtfs.Pattern{Route: gtfs.Route{ID: "L"}, ShapeID: "rush"}
+
+	var always, peak gtfs.Mask168
+	for d := 0; d < 7; d++ {
+		for h := 0; h < 24; h++ {
+			always = always.Set(d, h)
+		}
+		peak = peak.Set(d, 8)
+	}
+	SetPatternActs(map[string]gtfs.Mask168{
+		"L\x1fallday": always,
+		"L\x1frush":   peak,
+	})
+	defer SetPatternActs(nil)
+
+	seg := Segment{
+		Kind: "steady", Routes: []string{"L"},
+		Acts: []string{always.Hex()}, // SPLIT ORed both onto these edges
+		Line: line(0, 2000, 0),
+	}
+	paths := []Path{
+		// the all-day pattern drifted 300 m off the drawn centerline: no
+		// endpoint inside, and it rides nowhere near it
+		{Pattern: allDay, Line: line(-500, 2500, 300)},
+		// the rush pattern short-turns 700 m in and does ride the line
+		{Pattern: rush, Line: line(-500, 700, 0)},
+	}
+	out := CutSegmentsAtTerminals([]Segment{seg}, paths, nil)
+	for _, sg := range out {
+		if sg.Acts[0] != always.Hex() {
+			t.Fatalf("a 24/7 railway lost its hours to a rush-only pattern: %s", sg.Acts[0])
+		}
+	}
+
+	// and once that pattern is back ON the centerline, refinement runs
+	// again: the far piece keeps only the all-day hours
+	paths[0].Line = line(-500, 2500, 0)
+	out = CutSegmentsAtTerminals([]Segment{seg}, paths, nil)
+	if len(out) != 2 {
+		t.Fatalf("want 2 pieces once reconstructible, got %d", len(out))
+	}
+	if out[0].Acts[0] != always.Or(peak).Hex() || out[1].Acts[0] != always.Hex() {
+		t.Fatalf("near=%s far=%s", out[0].Acts[0], out[1].Acts[0])
+	}
+}

--- a/internal/sync/assemble.go
+++ b/internal/sync/assemble.go
@@ -1,0 +1,419 @@
+package sync
+
+// Chart-request assembly from a registry entry — the Go port of
+// tools/feed.sh `build` (plus tools/groupbuild.sh's preflight), which
+// remain the prose originals. The output is an ARGV for `portolan
+// chart`, not a ChartOpts: the executor runs each build as a child
+// process (builds are process-isolated because chart configuration is
+// process state — see `portolan serve`'s serialization note), so the
+// child's own flag definitions parse everything, chart_args included.
+// feed.sh does exactly the same word-splitting hand-off.
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alexwohlbruck/portolan/internal/registry"
+)
+
+// buildSpec is one assembled build: the argv after "chart", and what the
+// executor needs to know about the outputs.
+type buildSpec struct {
+	Key  string
+	Argv []string
+	Out  string
+	Zips []string // the gtfs list, split — fingerprint inputs
+}
+
+// outPath: the entry's out, defaulting to the same convention feed.sh
+// and groups.py assume (build/<key>.geojson).
+func outPath(fc registry.FeedCfg, buildDir, key string) string {
+	if fc.Out != "" {
+		return fc.Out
+	}
+	return filepath.Join(buildDir, key+".geojson")
+}
+
+// assembleChart mirrors feed.sh build line by line: geometry source,
+// gtfs list, window, ceded windows, style layering, streets, stops,
+// export, chart_args. doc is the order-preserved registry document —
+// the exclude-window scan walks entries in file order, exactly as the
+// jq derivation does. exportGTFS is empty for builds that must not
+// export (groups: their member zips belong to the members' own builds).
+func assembleChart(doc *Obj, cfg registry.Config, key, buildDir, styleDir,
+	exportGTFS string, logf func(string, ...any)) (*buildSpec, error) {
+	fc, ok := cfg.Feeds[key]
+	if !ok {
+		return nil, fmt.Errorf("%s: not in the registry", key)
+	}
+	out := outPath(fc, buildDir, key)
+
+	if fc.Corridors != "" {
+		if st, err := os.Stat(fc.Corridors); err != nil || st.Size() == 0 {
+			return nil, fmt.Errorf("%s: no corridor graph at %s", key, fc.Corridors)
+		}
+	} else {
+		if st, err := os.Stat(fc.Rail); fc.Rail == "" || err != nil || st.Size() == 0 {
+			return nil, fmt.Errorf("%s: no rail extract at %s", key, fc.Rail)
+		}
+	}
+	var zips []string
+	for _, part := range strings.Split(fc.GTFS, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if st, err := os.Stat(part); err != nil || st.Size() == 0 {
+			return nil, fmt.Errorf("%s: no GTFS at %s", key, part)
+		}
+		zips = append(zips, part)
+	}
+	if len(zips) == 0 {
+		return nil, fmt.Errorf("%s: no gtfs configured", key)
+	}
+
+	var argv []string
+	if fc.Corridors != "" {
+		argv = []string{"--gtfs", fc.GTFS, "--corridors", fc.Corridors, "--out", out}
+	} else {
+		argv = []string{"--gtfs", fc.GTFS, "--rail", fc.Rail, "--out", out}
+	}
+	if len(fc.BBox) == 4 {
+		argv = append(argv, "--bbox", bboxArg(fc.BBox))
+	}
+	// a feed that also rides in GROUP builds as an overlay cedes those
+	// windows — derived from the groups' gtfs lists, so it cannot rot
+	// (feed.sh ~190-201). Members keep their full standalone builds.
+	if ex := cededWindows(doc, key, fc.PrimaryGTFS()); ex != "" {
+		argv = append(argv, "--exclude-bbox", ex)
+	}
+	// style: _default → member docs → overlay docs → own doc, through the
+	// one Go loader (style.LoadDir) the chart child resolves --feed with
+	styleFeed := key
+	if names := append(append([]string(nil), fc.Members...), fc.Overlays...); len(names) > 0 {
+		styleFeed = strings.Join(append(names, key), ",")
+	}
+	argv = append(argv, "--style-dir", styleDir, "--feed", styleFeed)
+	if fc.Streets != "" {
+		if st, err := os.Stat(fc.Streets); err == nil && st.Size() > 0 {
+			argv = append(argv, "--streets", fc.Streets)
+		} else {
+			logf("%s: streets configured but missing at %s — building rail-only", key, fc.Streets)
+		}
+	}
+	if fc.Stops != "" {
+		if st, err := os.Stat(fc.Stops); err == nil && st.Size() > 0 {
+			argv = append(argv, "--stops", fc.Stops)
+		}
+	}
+	if exportGTFS != "" {
+		argv = append(argv, "--export-gtfs", exportGTFS)
+	}
+	// onestop ids ride in from the registry for every zip in the build —
+	// by hand this is chart --onestop (docs/SYNC.md tile contract)
+	if ids := onestopArg(cfg, zips); ids != "" {
+		argv = append(argv, "--onestop", ids)
+	}
+	// chart_args: per-feed extra chart flags, word-split exactly as the
+	// shell would split them, parsed by chart's own flag set
+	argv = append(argv, strings.Fields(fc.ChartArgs)...)
+	return &buildSpec{Key: key, Argv: argv, Out: out, Zips: zips}, nil
+}
+
+// bboxArg formats a window the way jq's join(",") formats the registry's
+// numbers — shortest float form.
+func bboxArg(b []float64) string {
+	parts := make([]string, len(b))
+	for i, v := range b {
+		parts[i] = trimFloat(v)
+	}
+	return strings.Join(parts, ",")
+}
+
+func trimFloat(v float64) string {
+	s := fmt.Sprintf("%g", v)
+	if math.Abs(v) >= 1e6 { // %g switches to exponent; bboxes never do
+		s = fmt.Sprintf("%f", v)
+	}
+	return s
+}
+
+// cededWindows: the exclude-bbox derivation of feed.sh — every OTHER
+// entry that is a group (members non-empty), does NOT list this feed as
+// a member, and charts this feed's primary zip in its gtfs list, cedes
+// its bbox. Windows join with ";" in registry file order.
+func cededWindows(doc *Obj, key, primary string) string {
+	feeds := feedsObj(doc)
+	var wins []string
+	for _, k := range feeds.Keys() {
+		if k == key {
+			continue
+		}
+		v, _ := feeds.Get(k)
+		e, ok := v.(*Obj)
+		if !ok {
+			continue
+		}
+		members := strsOf(e, "members")
+		if len(members) == 0 {
+			continue
+		}
+		isMember := false
+		for _, m := range members {
+			if m == key {
+				isMember = true
+				break
+			}
+		}
+		if isMember {
+			continue
+		}
+		carries := false
+		for _, p := range strings.Split(e.Str("gtfs"), ",") {
+			if strings.TrimSpace(p) == primary {
+				carries = true
+				break
+			}
+		}
+		if !carries {
+			continue
+		}
+		b, ok := e.Get("bbox")
+		if !ok {
+			continue
+		}
+		arr, _ := b.([]any)
+		parts := make([]string, 0, len(arr))
+		for _, x := range arr {
+			switch t := x.(type) {
+			case json.Number:
+				parts = append(parts, t.String())
+			case float64:
+				parts = append(parts, trimFloat(t))
+			}
+		}
+		if len(parts) == 4 {
+			wins = append(wins, strings.Join(parts, ","))
+		}
+	}
+	return strings.Join(wins, ";")
+}
+
+// onestopArg builds the --onestop value: for each zip of the build, the
+// onestop id of the registry feed whose primary gtfs is that zip, keyed
+// by zip basename sans ".zip" (the key chart's flag wants).
+func onestopArg(cfg registry.Config, zips []string) string {
+	byPrimary := map[string]string{}
+	for _, fc := range cfg.Feeds {
+		if len(fc.Members) > 0 || fc.Onestop == "" {
+			continue
+		}
+		if p := fc.PrimaryGTFS(); p != "" {
+			byPrimary[p] = fc.Onestop
+		}
+	}
+	var kv []string
+	seen := map[string]bool{}
+	for _, z := range zips {
+		id := byPrimary[z]
+		if id == "" {
+			continue
+		}
+		k := strings.TrimSuffix(filepath.Base(z), ".zip")
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		kv = append(kv, k+"="+id)
+	}
+	return strings.Join(kv, ",")
+}
+
+// ---------------------------------------------------------------- merge
+
+// mergeFC is the tools/mergefc.py port: concatenate GeoJSON
+// FeatureCollections, first wins on duplicate feature id — the same OSM
+// way must not enter the bundler twice, or the copies read as parallel
+// tracks. Features without an id are kept unconditionally. The result
+// writes to dst atomically.
+func mergeFC(dst string, srcs []string) (int, error) {
+	type feature struct {
+		ID    any             `json:"id,omitempty"`
+		Type  string          `json:"type"`
+		Props json.RawMessage `json:"properties,omitempty"`
+		Geom  json.RawMessage `json:"geometry"`
+	}
+	seen := map[string]bool{}
+	var feats []feature
+	for _, src := range srcs {
+		raw, err := os.ReadFile(src)
+		if err != nil {
+			return 0, err
+		}
+		var fc struct {
+			Features []feature `json:"features"`
+		}
+		if err := json.Unmarshal(raw, &fc); err != nil {
+			return 0, fmt.Errorf("%s: %w", src, err)
+		}
+		for _, f := range fc.Features {
+			if f.ID != nil {
+				id := fmt.Sprint(f.ID)
+				if seen[id] {
+					continue
+				}
+				seen[id] = true
+			}
+			feats = append(feats, f)
+		}
+	}
+	out := struct {
+		Type     string    `json:"type"`
+		Features []feature `json:"features"`
+	}{Type: "FeatureCollection", Features: feats}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return 0, err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return 0, err
+	}
+	if err := atomicWrite(dst, append(raw, '\n')); err != nil {
+		return 0, err
+	}
+	return len(feats), nil
+}
+
+// ------------------------------------------------------------ preflight
+
+// groupPreflight is groupbuild.sh's per-group preparation, minus the
+// network calls sync must never make: a rail extract that is missing or
+// does not cover the window is MERGED from the members' (and overlays')
+// own extracts instead of fetched from Overpass; a missing stops extract
+// merges the same way; streets_from merges into streets (mergefc, as the
+// shell does). Merged extracts overlap where windows meet — mergeFC's
+// id-dedup is what keeps the shared way single.
+func groupPreflight(cfg registry.Config, key, buildDir string,
+	logf func(string, ...any)) error {
+	fc := cfg.Feeds[key]
+	tied := append(append([]string(nil), fc.Members...), fc.Overlays...)
+
+	collect := func(pathOf func(registry.FeedCfg) string) []string {
+		var srcs []string
+		seen := map[string]bool{}
+		for _, m := range tied {
+			mc, ok := cfg.Feeds[m]
+			if !ok {
+				continue
+			}
+			p := pathOf(mc)
+			if p == "" || seen[p] {
+				continue
+			}
+			if st, err := os.Stat(p); err != nil || st.Size() == 0 {
+				continue
+			}
+			seen[p] = true
+			srcs = append(srcs, p)
+		}
+		return srcs
+	}
+
+	if fc.Rail != "" && !railCovers(fc.Rail, fc.BBox) {
+		srcs := collect(func(m registry.FeedCfg) string { return m.Rail })
+		if len(srcs) == 0 {
+			return fmt.Errorf("%s: rail extract at %s does not cover the window and no member extract exists to merge", key, fc.Rail)
+		}
+		n, err := mergeFC(fc.Rail, srcs)
+		if err != nil {
+			return fmt.Errorf("%s: merging rail extracts: %w", key, err)
+		}
+		logf("%s: merged rail extract from %d member extracts (%d ways) — sync never calls Overpass", key, len(srcs), n)
+	}
+	if fc.Stops != "" {
+		if st, err := os.Stat(fc.Stops); err != nil || st.Size() == 0 {
+			if srcs := collect(func(m registry.FeedCfg) string { return m.Stops }); len(srcs) > 0 {
+				n, err := mergeFC(fc.Stops, srcs)
+				if err != nil {
+					return fmt.Errorf("%s: merging stops extracts: %w", key, err)
+				}
+				logf("%s: merged stops extract from %d member extracts (%d stops)", key, len(srcs), n)
+			}
+		}
+	}
+	// members with DIFFERENT street extracts need one merged extract, or
+	// the group draws only the buses of whichever member's file it names
+	if len(fc.StreetsFrom) > 0 && fc.Streets != "" {
+		if st, err := os.Stat(fc.Streets); err != nil || st.Size() == 0 {
+			n, err := mergeFC(fc.Streets, fc.StreetsFrom)
+			if err != nil {
+				return fmt.Errorf("%s: merging streets: %w", key, err)
+			}
+			logf("%s: merged streets from %v (%d ways)", key, fc.StreetsFrom, n)
+		}
+	}
+	return nil
+}
+
+// railCovers ports groupbuild.sh's coverage check: the extract exists,
+// is more than trivially small, and its feature extent covers the
+// group's bbox within 0.05 degrees of slack.
+func railCovers(path string, bbox []float64) bool {
+	st, err := os.Stat(path)
+	if err != nil || st.Size() < 2048 {
+		return false
+	}
+	if len(bbox) != 4 {
+		return true
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var fc struct {
+		Features []struct {
+			Geometry struct {
+				Type        string          `json:"type"`
+				Coordinates json.RawMessage `json:"coordinates"`
+			} `json:"geometry"`
+		} `json:"features"`
+	}
+	if json.Unmarshal(raw, &fc) != nil {
+		return false
+	}
+	w, s := math.Inf(1), math.Inf(1)
+	e, n := math.Inf(-1), math.Inf(-1)
+	take := func(c [2]float64) {
+		w = math.Min(w, c[0])
+		e = math.Max(e, c[0])
+		s = math.Min(s, c[1])
+		n = math.Max(n, c[1])
+	}
+	for _, f := range fc.Features {
+		switch f.Geometry.Type {
+		case "LineString":
+			var pts [][2]float64
+			if json.Unmarshal(f.Geometry.Coordinates, &pts) != nil {
+				continue
+			}
+			for _, c := range pts {
+				take(c)
+			}
+		case "MultiLineString":
+			var parts [][][2]float64
+			if json.Unmarshal(f.Geometry.Coordinates, &parts) != nil {
+				continue
+			}
+			for _, pts := range parts {
+				for _, c := range pts {
+					take(c)
+				}
+			}
+		}
+	}
+	return w-0.05 <= bbox[0] && s-0.05 <= bbox[1] && e+0.05 >= bbox[2] && n+0.05 >= bbox[3]
+}

--- a/internal/sync/check.go
+++ b/internal/sync/check.go
@@ -1,0 +1,142 @@
+package sync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/alexwohlbruck/portolan/internal/registry"
+)
+
+// CheckOpts wires one check run: the registry says which feeds exist, the
+// manifest at StatePath says what we last saw, the client asks upstream.
+type CheckOpts struct {
+	Config    registry.Config
+	StatePath string
+	DataDir   string // downloaded zips land here as <feedkey>.zip
+	Client    *Client
+	DryRun    bool // stop after the diff: no downloads, no state writes
+	Log       func(format string, a ...any)
+	// Now is injectable for tests; nil means time.Now.
+	Now func() time.Time
+}
+
+// CheckResult is the machine-readable outcome — the RESULT line's body.
+type CheckResult struct {
+	Changed []string `json:"changed"` // feeds whose content actually moved
+	Skipped []string `json:"skipped"` // feeds with no onestop id
+	Errors  []string `json:"errors"`  // "feed: what went wrong", run continued
+}
+
+// Check asks transitland for every registered feed's current version sha,
+// diffs against the manifest, and downloads what moved into DataDir. A
+// changed sha over identical content records the new sha but does not
+// count as changed — the content hash is the identity that matters. The
+// manifest is saved after each feed, so an interrupted run resumes where
+// it stopped. One feed's failure lands in Errors; the run carries on.
+func Check(o CheckOpts) (CheckResult, error) {
+	res := CheckResult{Changed: []string{}, Skipped: []string{}, Errors: []string{}}
+	logf := o.Log
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	now := o.Now
+	if now == nil {
+		now = time.Now
+	}
+	st, err := LoadState(o.StatePath)
+	if err != nil {
+		return res, err
+	}
+
+	keys := make([]string, 0, len(o.Config.Feeds))
+	for k := range o.Config.Feeds {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	oops := func(key string, err error) {
+		res.Errors = append(res.Errors, key+": "+err.Error())
+		logf("%s: %v", key, err)
+	}
+	for _, key := range keys {
+		fc := o.Config.Feeds[key]
+		if fc.Onestop == "" {
+			res.Skipped = append(res.Skipped, key)
+			logf("%s: no onestop id — skipped", key)
+			continue
+		}
+		info, err := o.Client.Feed(fc.Onestop)
+		if err != nil {
+			oops(key, err)
+			continue
+		}
+		if info.SHA1 == "" {
+			oops(key, fmt.Errorf("%s: no feed version upstream", fc.Onestop))
+			continue
+		}
+		prev := st.Feeds[key]
+		if info.SHA1 == prev.SHA1 {
+			logf("%s: unchanged (%s)", key, short(info.SHA1))
+			continue
+		}
+		if o.DryRun {
+			res.Changed = append(res.Changed, key)
+			logf("%s: upstream %s, have %s — would download", key, short(info.SHA1), short(prev.SHA1))
+			continue
+		}
+		dest := filepath.Join(o.DataDir, key+".zip")
+		tmp := dest + ".sync"
+		if err := o.Client.Download(fc.Onestop, info.StaticCurrent, tmp); err != nil {
+			oops(key, err)
+			continue
+		}
+		content, err := ContentHash(tmp)
+		if err != nil {
+			os.Remove(tmp)
+			oops(key, err)
+			continue
+		}
+		cur := prev
+		cur.Onestop = fc.Onestop
+		cur.SHA1 = info.SHA1
+		if content == prev.Content && prev.Content != "" {
+			// a republish: new sha, same tables — record the sha so the
+			// next check is quiet, but nothing downstream needs to move
+			os.Remove(tmp)
+			logf("%s: new sha %s over identical content — recorded", key, short(info.SHA1))
+		} else {
+			if err := os.Rename(tmp, dest); err != nil {
+				os.Remove(tmp)
+				oops(key, err)
+				continue
+			}
+			cur.Content = content
+			res.Changed = append(res.Changed, key)
+			logf("%s: changed → %s", key, dest)
+		}
+		st.Feeds[key] = cur
+		if err := st.Save(o.StatePath); err != nil {
+			return res, err
+		}
+	}
+	if !o.DryRun {
+		st.LastCheck = now().UTC().Format(time.RFC3339)
+		if err := st.Save(o.StatePath); err != nil {
+			return res, err
+		}
+	}
+	return res, nil
+}
+
+func short(sha string) string {
+	if sha == "" {
+		return "nothing"
+	}
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}

--- a/internal/sync/check_test.go
+++ b/internal/sync/check_test.go
@@ -1,0 +1,308 @@
+package sync
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alexwohlbruck/portolan/internal/registry"
+)
+
+// tlStub plays transitland: one feed record, a direct download that can
+// be licence-blocked, and the operator's static URL. The client is
+// sequential, so plain counters need no locking.
+type tlStub struct {
+	sha1      string
+	zip       []byte // served by download_latest_feed_version
+	noDirect  bool   // …unless licence-blocked: 404
+	staticZip []byte // served at /static.zip
+	staticURL string
+
+	feedHits, dlHits, staticHits int
+	apikey                       string
+}
+
+func newTL(t *testing.T, s *tlStub) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.apikey = r.URL.Query().Get("apikey")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/download_latest_feed_version"):
+			s.dlHits++
+			if s.noDirect {
+				http.Error(w, "licence", http.StatusNotFound)
+				return
+			}
+			w.Write(s.zip)
+		case r.URL.Path == "/static.zip":
+			s.staticHits++
+			w.Write(s.staticZip)
+		case strings.HasPrefix(r.URL.Path, "/feeds/"):
+			s.feedHits++
+			if strings.Contains(r.URL.Path, "f-bad") {
+				// a registered feed transitland has no version for
+				fmt.Fprint(w, `{"feeds":[{"feed_state":{},"urls":{}}]}`)
+				return
+			}
+			fmt.Fprintf(w, `{"feeds":[{"feed_state":{"feed_version":{"sha1":%q}},"urls":{"static_current":%q}}]}`,
+				s.sha1, s.staticURL)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	s.staticURL = srv.URL + "/static.zip"
+	return &Client{BaseURL: srv.URL, APIKey: "k", Sleep: func(time.Duration) {}}
+}
+
+func metroConfig() registry.Config {
+	return registry.Config{Feeds: map[string]registry.FeedCfg{
+		"metro": {GTFS: "data/gtfs/metro.zip", Onestop: "f-abc-metro"},
+	}}
+}
+
+func checkOpts(t *testing.T, c *Client, dry bool) CheckOpts {
+	t.Helper()
+	dir := t.TempDir()
+	return CheckOpts{
+		Config:    metroConfig(),
+		StatePath: filepath.Join(dir, "build", "sync-state.json"),
+		DataDir:   filepath.Join(dir, "data"),
+		Client:    c,
+		DryRun:    dry,
+	}
+}
+
+func TestCheckDownloadsNewFeed(t *testing.T) {
+	stub := &tlStub{sha1: "s1", zip: zipBytes(t, []member{{"routes.txt", "route_id\nA\n"}})}
+	c := newTL(t, stub)
+	o := checkOpts(t, c, false)
+
+	res, err := Check(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Changed) != 1 || res.Changed[0] != "metro" {
+		t.Fatalf("changed = %v", res.Changed)
+	}
+	if stub.apikey != "k" {
+		t.Errorf("apikey not sent: %q", stub.apikey)
+	}
+	if _, err := os.Stat(filepath.Join(o.DataDir, "metro.zip")); err != nil {
+		t.Errorf("zip not installed: %v", err)
+	}
+	st, err := LoadState(o.StatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := st.Feeds["metro"]
+	if fs.SHA1 != "s1" || fs.Content == "" || fs.Onestop != "f-abc-metro" {
+		t.Errorf("state = %+v", fs)
+	}
+	if st.LastCheck == "" {
+		t.Error("last_check not recorded")
+	}
+
+	// same sha again: quiet, and no second download
+	res, err = Check(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Changed) != 0 || stub.dlHits != 1 {
+		t.Errorf("rerun: changed=%v dlHits=%d", res.Changed, stub.dlHits)
+	}
+}
+
+func TestCheckRepublishIdenticalContent(t *testing.T) {
+	stub := &tlStub{sha1: "s1", zip: zipBytes(t, []member{{"routes.txt", "route_id\nA\n"}})}
+	c := newTL(t, stub)
+	o := checkOpts(t, c, false)
+	if _, err := Check(o); err != nil {
+		t.Fatal(err)
+	}
+
+	// transitland republishes: new sha, same tables
+	stub.sha1 = "s2"
+	res, err := Check(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Changed) != 0 {
+		t.Errorf("identical content flagged as changed: %v", res.Changed)
+	}
+	if stub.dlHits != 2 {
+		t.Errorf("dlHits = %d, want 2 (must download to compare)", stub.dlHits)
+	}
+	st, _ := LoadState(o.StatePath)
+	if st.Feeds["metro"].SHA1 != "s2" {
+		t.Errorf("new sha not recorded: %+v", st.Feeds["metro"])
+	}
+
+	// third run: the recorded sha keeps it quiet with no download
+	if _, err := Check(o); err != nil {
+		t.Fatal(err)
+	}
+	if stub.dlHits != 2 {
+		t.Errorf("republish re-downloaded: dlHits = %d", stub.dlHits)
+	}
+}
+
+func TestCheckChangedContent(t *testing.T) {
+	stub := &tlStub{sha1: "s1", zip: zipBytes(t, []member{{"routes.txt", "route_id\nA\n"}})}
+	c := newTL(t, stub)
+	o := checkOpts(t, c, false)
+	if _, err := Check(o); err != nil {
+		t.Fatal(err)
+	}
+	before, _ := LoadState(o.StatePath)
+
+	stub.sha1 = "s2"
+	stub.zip = zipBytes(t, []member{{"routes.txt", "route_id\nB\n"}})
+	res, err := Check(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Changed) != 1 {
+		t.Fatalf("changed = %v", res.Changed)
+	}
+	after, _ := LoadState(o.StatePath)
+	if after.Feeds["metro"].Content == before.Feeds["metro"].Content {
+		t.Error("content hash did not move")
+	}
+}
+
+func TestCheckFallbackToStaticCurrent(t *testing.T) {
+	z := zipBytes(t, []member{{"routes.txt", "route_id\nA\n"}})
+	stub := &tlStub{sha1: "s1", noDirect: true, staticZip: z}
+	c := newTL(t, stub)
+	o := checkOpts(t, c, false)
+
+	res, err := Check(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Changed) != 1 || len(res.Errors) != 0 {
+		t.Fatalf("changed=%v errors=%v", res.Changed, res.Errors)
+	}
+	if stub.staticHits != 1 {
+		t.Errorf("staticHits = %d", stub.staticHits)
+	}
+	if _, err := os.Stat(filepath.Join(o.DataDir, "metro.zip")); err != nil {
+		t.Errorf("zip not installed via fallback: %v", err)
+	}
+}
+
+func TestCheckSkipsFeedsWithoutOnestop(t *testing.T) {
+	stub := &tlStub{sha1: "s1", zip: zipBytes(t, []member{{"routes.txt", "r\n"}})}
+	c := newTL(t, stub)
+	o := checkOpts(t, c, false)
+	o.Config = registry.Config{Feeds: map[string]registry.FeedCfg{
+		"handmade": {GTFS: "data/gtfs/handmade.zip"},
+	}}
+	res, err := Check(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Skipped) != 1 || res.Skipped[0] != "handmade" {
+		t.Errorf("skipped = %v", res.Skipped)
+	}
+	if stub.feedHits != 0 {
+		t.Errorf("asked upstream about a feed with no onestop id")
+	}
+}
+
+func TestCheckDryRun(t *testing.T) {
+	stub := &tlStub{sha1: "s1", zip: zipBytes(t, []member{{"routes.txt", "r\n"}})}
+	c := newTL(t, stub)
+	o := checkOpts(t, c, true)
+
+	res, err := Check(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Changed) != 1 {
+		t.Fatalf("changed = %v", res.Changed)
+	}
+	if stub.dlHits != 0 {
+		t.Errorf("dry run downloaded: dlHits = %d", stub.dlHits)
+	}
+	if _, err := os.Stat(o.StatePath); err == nil {
+		t.Error("dry run wrote state")
+	}
+}
+
+func TestCheckOneFailureDoesNotAbort(t *testing.T) {
+	stub := &tlStub{sha1: "s1", zip: zipBytes(t, []member{{"routes.txt", "r\n"}})}
+	c := newTL(t, stub)
+	o := checkOpts(t, c, false)
+	// "aaa" sorts before metro and has no upstream version — its error
+	// must land in Errors while metro still downloads
+	o.Config.Feeds["aaa"] = registry.FeedCfg{GTFS: "x.zip", Onestop: "f-bad"}
+
+	res, err := Check(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Errors) != 1 || !strings.HasPrefix(res.Errors[0], "aaa:") {
+		t.Errorf("errors = %v", res.Errors)
+	}
+	if len(res.Changed) != 1 || res.Changed[0] != "metro" {
+		t.Errorf("changed = %v — the run should have carried on", res.Changed)
+	}
+}
+
+func TestClient429RetriesOnce(t *testing.T) {
+	hits, slept := 0, time.Duration(0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if hits == 1 {
+			w.Header().Set("Retry-After", "3")
+			http.Error(w, "slow down", http.StatusTooManyRequests)
+			return
+		}
+		fmt.Fprint(w, `{"feeds":[{"feed_state":{"feed_version":{"sha1":"s1"}},"urls":{}}]}`)
+	}))
+	defer srv.Close()
+	c := &Client{BaseURL: srv.URL, Sleep: func(d time.Duration) { slept = d }}
+	info, err := c.Feed("f-abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.SHA1 != "s1" || hits != 2 || slept != 3*time.Second {
+		t.Errorf("sha=%q hits=%d slept=%v", info.SHA1, hits, slept)
+	}
+}
+
+func TestClientErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := &Client{BaseURL: srv.URL, Sleep: func(time.Duration) {}}
+	if _, err := c.Feed("f-abc"); err == nil {
+		t.Error("500 reported as success")
+	}
+	if err := c.Download("f-abc", "", filepath.Join(t.TempDir(), "x.zip")); err == nil {
+		t.Error("download of a 500 reported as success")
+	}
+}
+
+func TestDownloadRejectsNonZip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "<html>please sign in</html>")
+	}))
+	defer srv.Close()
+	c := &Client{BaseURL: srv.URL, Sleep: func(time.Duration) {}}
+	dest := filepath.Join(t.TempDir(), "x.zip")
+	if err := c.Download("f-abc", "", dest); err == nil {
+		t.Error("HTML page installed as a feed zip")
+	}
+	if _, err := os.Stat(dest); err == nil {
+		t.Error("bad download left a file behind")
+	}
+}

--- a/internal/sync/fingerprint.go
+++ b/internal/sync/fingerprint.go
@@ -1,0 +1,48 @@
+package sync
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// ContentHash fingerprints a GTFS zip by what it says, not how it was
+// compressed: sha256 over the *.txt members sorted by name, each framed
+// as name, uncompressed size, then bytes. Two zips holding the same
+// tables hash the same regardless of member order or compression level —
+// how a transitland republish under a new sha is recognized as the same
+// feed. Members stream through the hash; nothing is slurped whole.
+func ContentHash(zipPath string) (string, error) {
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", zipPath, err)
+	}
+	defer zr.Close()
+
+	var members []*zip.File
+	for _, f := range zr.File {
+		if strings.HasSuffix(f.Name, ".txt") {
+			members = append(members, f)
+		}
+	}
+	sort.Slice(members, func(i, j int) bool { return members[i].Name < members[j].Name })
+
+	h := sha256.New()
+	for _, f := range members {
+		fmt.Fprintf(h, "%s\x00%d\x00", f.Name, f.UncompressedSize64)
+		rc, err := f.Open()
+		if err != nil {
+			return "", fmt.Errorf("%s: %s: %w", zipPath, f.Name, err)
+		}
+		if _, err := io.Copy(h, rc); err != nil {
+			rc.Close()
+			return "", fmt.Errorf("%s: %s: %w", zipPath, f.Name, err)
+		}
+		rc.Close()
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/sync/fingerprint_test.go
+++ b/internal/sync/fingerprint_test.go
@@ -1,0 +1,96 @@
+package sync
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// member is one zip entry, in the order it should be written — the whole
+// point of several tests is that write order must not matter.
+type member struct{ name, body string }
+
+func zipBytes(t *testing.T, members []member) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, m := range members {
+		w, err := zw.Create(m.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(m.body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func writeZip(t *testing.T, members []member) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "feed.zip")
+	if err := os.WriteFile(path, zipBytes(t, members), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestContentHashOrderIndependent(t *testing.T) {
+	a := writeZip(t, []member{
+		{"routes.txt", "route_id\nA\n"},
+		{"stops.txt", "stop_id\n1\n"},
+		{"trips.txt", "trip_id\nt1\n"},
+	})
+	b := writeZip(t, []member{
+		{"trips.txt", "trip_id\nt1\n"},
+		{"stops.txt", "stop_id\n1\n"},
+		{"routes.txt", "route_id\nA\n"},
+	})
+	ha, err := ContentHash(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hb, err := ContentHash(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ha != hb {
+		t.Errorf("same members, different order: %s != %s", ha, hb)
+	}
+}
+
+func TestContentHashSeesContent(t *testing.T) {
+	a := writeZip(t, []member{{"routes.txt", "route_id\nA\n"}})
+	b := writeZip(t, []member{{"routes.txt", "route_id\nB\n"}})
+	ha, _ := ContentHash(a)
+	hb, _ := ContentHash(b)
+	if ha == hb {
+		t.Error("different content, same hash")
+	}
+}
+
+func TestContentHashIgnoresNonTxt(t *testing.T) {
+	a := writeZip(t, []member{{"routes.txt", "route_id\nA\n"}})
+	b := writeZip(t, []member{
+		{"routes.txt", "route_id\nA\n"},
+		{"shapes.geojson", "{}"},
+	})
+	ha, _ := ContentHash(a)
+	hb, _ := ContentHash(b)
+	if ha != hb {
+		t.Error("a non-.txt member changed the hash")
+	}
+}
+
+func TestContentHashNotAZip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "feed.zip")
+	os.WriteFile(path, []byte("<html>rate limited</html>"), 0o644)
+	if _, err := ContentHash(path); err == nil {
+		t.Error("hashed an HTML page as a feed")
+	}
+}

--- a/internal/sync/groups.go
+++ b/internal/sync/groups.go
@@ -1,0 +1,469 @@
+package sync
+
+// Cross-feed group derivation — the Go port of tools/groups.py, which
+// remains the prose original; the constants and rules here mirror it
+// EXACTLY, because `sync patch` re-derives membership over the affected
+// component and its answer must be the one a full groups.py run would
+// give. Ribboning cannot cross a document: two agencies on the same
+// steel draw as two lines unless they are charted together, and WHICH
+// agencies those are is a measurement, not curation.
+//
+// Two roles come out of it, both by extent, because a group is a WINDOW:
+//
+//	members  — feeds small enough to sit inside one regional window.
+//	overlays — feeds too wide for any window (Amtrak, VIA); they join
+//	           every group they touch and cede those windows from their
+//	           own build.
+//
+// Grouping is deliberately PERMISSIVE — a false positive costs a
+// slightly larger document; a false negative draws the same rails twice.
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/alexwohlbruck/portolan/internal/geo"
+	"github.com/alexwohlbruck/portolan/internal/gtfs"
+	"github.com/alexwohlbruck/portolan/internal/registry"
+)
+
+// railTypes: which route_type STRINGS groups.py treats as rail. Matched
+// as strings against the raw CSV cell — "" (absent) is not rail.
+var railTypes = func() map[string]bool {
+	m := map[string]bool{}
+	for _, t := range []string{"0", "1", "2", "5", "6", "7", "12",
+		"400", "401", "402", "403", "405", "900"} {
+		m[t] = true
+	}
+	for t := 100; t < 118; t++ {
+		m[strconv.Itoa(t)] = true
+	}
+	return m
+}()
+
+// Constants — groups.py's, verbatim. A shared corridor is worth grouping
+// at 900 m: well below any real shared corridor (the shortest genuine
+// one in North America is the McKinney Avenue streetcar's 1.2 km beside
+// DART) and far above a level crossing, which shares one cell.
+const (
+	cellM      = 60.0  // GTFS shapes wander; 60 m survives it
+	minSharedM = 900.0 // sustained-run floor
+	stepM      = 30.0  // shape sampling
+
+	// A feed whose rail extent covers more than this is a corridor, not
+	// a region. Amtrak is 1247 deg², VIA 1200; the widest regional feed
+	// that stays a member is Brightline at 3.4.
+	maxMemberArea = 20.0 // square degrees
+
+	degM = 111320.0
+	latM = 110540.0
+
+	marginDeg = 0.03 // degrees of slack around the members' own shapes
+
+	// a build this small or smaller is "no build" for the undrawn rule
+	// (groups.py: os.path.getsize(b) > 3000, strict)
+	minBuildBytes = 3000
+)
+
+// Extent is [w, s, e, n].
+type Extent [4]float64
+
+func (e Extent) Area() float64 { return (e[2] - e[0]) * (e[3] - e[1]) }
+
+func (e Extent) union(o Extent) Extent {
+	return Extent{math.Min(e[0], o[0]), math.Min(e[1], o[1]),
+		math.Max(e[2], o[2]), math.Max(e[3], o[3])}
+}
+
+// Intersects — closed-interval bbox overlap, the patch prefilter.
+func (e Extent) Intersects(o Extent) bool {
+	return e[0] <= o[2] && o[0] <= e[2] && e[1] <= o[3] && o[1] <= e[3]
+}
+
+// GroupSpec is one derived group: sorted members, sorted overlays, and
+// the window — the union of member shape extents AND their configured
+// bboxes (the Charlotte rule: a group must never see less of a member
+// than the member sees of itself).
+type GroupSpec struct {
+	Members  []string
+	Overlays []string
+	Extent   Extent
+}
+
+// Derivation is everything one measurement pass established.
+type Derivation struct {
+	Groups []GroupSpec
+	// Measured: feeds with rail shapes, sorted — groups.py's `feeds`.
+	Measured []string
+	// Extent per measured feed (shape extent, not the configured bbox).
+	Extent map[string]Extent
+	// Length: each feed's own occupied run in metres (cells × 60).
+	Length map[string]float64
+	// Pairs: sorted feed pair → shared run in metres, only pairs ≥900 m.
+	Pairs map[[2]string]float64
+	// Duplicate: held-out feed → the feed it duplicates (>85% of BOTH).
+	Duplicate map[string]string
+	// Undrawn: feeds held out because no build ≥3000 bytes exists.
+	Undrawn []string
+}
+
+// SharedM: the shared run between two feeds, 0 when below the floor.
+func (d *Derivation) SharedM(a, b string) float64 {
+	if a > b {
+		a, b = b, a
+	}
+	return d.Pairs[[2]string{a, b}]
+}
+
+// sampleShapes walks every polyline at ~stepM, exactly as groups.py
+// samples: n interpolated points per segment (the endpoint arrives as
+// the next segment's start), segments needing >4000 samples skipped as
+// teleports, and each polyline's final point appended once.
+func sampleShapes(polys [][]geo.LL) [][2]float64 {
+	var out [][2]float64
+	for _, pts := range polys {
+		for i := 0; i+1 < len(pts); i++ {
+			a, b := pts[i], pts[i+1]
+			mx := degM * math.Cos(a.Lat*math.Pi/180)
+			dx, dy := (b.Lon-a.Lon)*mx, (b.Lat-a.Lat)*latM
+			n := int(math.Hypot(dx, dy) / stepM)
+			if n < 1 {
+				n = 1
+			}
+			if n > 4000 { // a shape with a teleport in it; skip the jump
+				continue
+			}
+			for j := 0; j < n; j++ {
+				out = append(out, [2]float64{
+					a.Lon + (b.Lon-a.Lon)*float64(j)/float64(n),
+					a.Lat + (b.Lat-a.Lat)*float64(j)/float64(n)})
+			}
+		}
+		if len(pts) > 0 {
+			last := pts[len(pts)-1]
+			out = append(out, [2]float64{last.Lon, last.Lat})
+		}
+	}
+	return out
+}
+
+type cell [2]int
+
+// cellOf truncates toward zero, like Python's int() — the two sides of
+// the meridian share cell 0 there too, and parity beats prettiness.
+func cellOf(p [2]float64) cell {
+	const cx, cy = cellM / degM, cellM / latM
+	return cell{int(p[0] / cx), int(p[1] / cy)}
+}
+
+// DeriveGroups measures the feeds and derives the groups. only, when
+// non-nil, restricts which registry feeds are read — the patch planner's
+// bbox-prefiltered closure; nil measures every feed whose zip exists
+// (the global/groups.py case). buildDir is where the undrawn rule looks
+// for default build outputs ("build" matches groups.py). Group entries
+// (Members set) are never measured: a group is an output, not an input.
+func DeriveGroups(cfg registry.Config, only map[string]bool, buildDir string,
+	logf func(string, ...any)) (*Derivation, error) {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	d := &Derivation{
+		Extent:    map[string]Extent{},
+		Length:    map[string]float64{},
+		Pairs:     map[[2]string]float64{},
+		Duplicate: map[string]string{},
+	}
+
+	// load: feed → sampled points, extent. Rail feeds with shapes only.
+	keys := make([]string, 0, len(cfg.Feeds))
+	for k := range cfg.Feeds {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	samples := map[string][][2]float64{}
+	for _, k := range keys {
+		fc := cfg.Feeds[k]
+		if len(fc.Members) > 0 {
+			continue // a group is an output of this, never an input
+		}
+		if only != nil && !only[k] {
+			continue
+		}
+		zip := fc.PrimaryGTFS()
+		if zip == "" {
+			continue
+		}
+		if _, err := os.Stat(zip); err != nil {
+			continue
+		}
+		polys, err := gtfs.RailShapes(zip, railTypes)
+		if err != nil { // a corrupt zip is not fatal
+			logf("  %s: unreadable (%v)", k, err)
+			continue
+		}
+		pts := sampleShapes(polys)
+		if len(pts) == 0 {
+			continue
+		}
+		ext := Extent{math.Inf(1), math.Inf(1), math.Inf(-1), math.Inf(-1)}
+		for _, p := range pts {
+			ext[0] = math.Min(ext[0], p[0])
+			ext[1] = math.Min(ext[1], p[1])
+			ext[2] = math.Max(ext[2], p[0])
+			ext[3] = math.Max(ext[3], p[1])
+		}
+		samples[k] = pts
+		d.Extent[k] = ext
+		d.Measured = append(d.Measured, k)
+	}
+
+	// shared steel, counted in OCCUPIED CELLS so a pair's shared run and
+	// a feed's own length are the same unit — the duplicate test compares
+	// the two.
+	grid := map[cell]map[string]bool{}
+	for _, k := range d.Measured {
+		own := map[cell]bool{}
+		for _, p := range samples[k] {
+			c := cellOf(p)
+			own[c] = true
+			if grid[c] == nil {
+				grid[c] = map[string]bool{}
+			}
+			grid[c][k] = true
+		}
+		d.Length[k] = float64(len(own)) * cellM
+	}
+	hits := map[[2]string]int{}
+	for _, fs := range grid {
+		if len(fs) < 2 {
+			continue
+		}
+		fl := make([]string, 0, len(fs))
+		for k := range fs {
+			fl = append(fl, k)
+		}
+		sort.Strings(fl)
+		for i := range fl {
+			for j := i + 1; j < len(fl); j++ {
+				hits[[2]string{fl[i], fl[j]}]++
+			}
+		}
+	}
+	for p, n := range hits {
+		if m := float64(n) * cellM; m >= minSharedM {
+			d.Pairs[p] = m
+		}
+	}
+
+	// duplicates: the SAME railway published twice. Charting them
+	// together would draw the line twice side by side in one document, so
+	// the smaller one is held out and reported for a human to retire.
+	pairKeys := make([][2]string, 0, len(d.Pairs))
+	for p := range d.Pairs {
+		pairKeys = append(pairKeys, p)
+	}
+	sort.Slice(pairKeys, func(i, j int) bool {
+		if pairKeys[i][0] != pairKeys[j][0] {
+			return pairKeys[i][0] < pairKeys[j][0]
+		}
+		return pairKeys[i][1] < pairKeys[j][1]
+	})
+	for _, p := range pairKeys {
+		a, b := p[0], p[1]
+		m, la, lb := d.Pairs[p], d.Length[a], d.Length[b]
+		if la > 0 && lb > 0 && m/la > 0.85 && m/lb > 0.85 {
+			loser, keeper := b, a
+			if la < lb {
+				loser, keeper = a, b
+			}
+			d.Duplicate[loser] = keeper
+		}
+	}
+
+	// undrawn: a feed that does not draw on its own today is not made a
+	// member — a pattern that cannot match can gate the whole group
+	// build, taking its co-members down with it.
+	for _, k := range d.Measured {
+		out := cfg.Feeds[k].Out
+		if out == "" {
+			out = filepath.Join(buildDir, k+".geojson")
+		}
+		if st, err := os.Stat(out); err != nil || st.Size() <= minBuildBytes {
+			d.Undrawn = append(d.Undrawn, k)
+		}
+	}
+	undrawn := map[string]bool{}
+	for _, k := range d.Undrawn {
+		undrawn[k] = true
+	}
+
+	// connected components over the MEMBER-eligible feeds; wide feeds
+	// are overlays and deliberately do not join components, or Amtrak
+	// would weld the continent into one document. A held-out feed is held
+	// out of BOTH roles.
+	member := map[string]bool{}
+	for _, k := range d.Measured {
+		if d.Extent[k].Area() <= maxMemberArea &&
+			d.Duplicate[k] == "" && !undrawn[k] {
+			member[k] = true
+		}
+	}
+	parent := map[string]string{}
+	for k := range member {
+		parent[k] = k
+	}
+	var find func(string) string
+	find = func(a string) string {
+		for parent[a] != a {
+			parent[a] = parent[parent[a]]
+			a = parent[a]
+		}
+		return a
+	}
+	for _, p := range pairKeys {
+		if member[p[0]] && member[p[1]] {
+			ra, rb := find(p[0]), find(p[1])
+			if ra != rb {
+				parent[ra] = rb
+			}
+		}
+	}
+	comps := map[string][]string{}
+	for k := range member {
+		r := find(k)
+		comps[r] = append(comps[r], k)
+	}
+	roots := make([]string, 0, len(comps))
+	for r := range comps {
+		roots = append(roots, r)
+	}
+	sort.Strings(roots)
+
+	cfgBBox := map[string]Extent{}
+	for k, v := range cfg.Feeds {
+		if len(v.BBox) == 4 {
+			cfgBBox[k] = Extent{v.BBox[0], v.BBox[1], v.BBox[2], v.BBox[3]}
+		}
+	}
+
+	for _, r := range roots {
+		ms := comps[r]
+		sort.Strings(ms)
+		// a lone feed is still a group when a corridor feed rides over it
+		// — that is the Hartford Line and the Rail Runner
+		overSet := map[string]bool{}
+		for _, o := range d.Measured {
+			if member[o] || d.Duplicate[o] != "" || undrawn[o] {
+				continue
+			}
+			for _, m := range ms {
+				if d.SharedM(o, m) > 0 {
+					overSet[o] = true
+					break
+				}
+			}
+		}
+		over := make([]string, 0, len(overSet))
+		for o := range overSet {
+			over = append(over, o)
+		}
+		sort.Strings(over)
+		if len(ms)+len(over) < 2 {
+			continue
+		}
+		// The window is the union of the members' shape extents AND of
+		// the windows they are already built with — the Charlotte rule.
+		ext := d.Extent[ms[0]]
+		for _, m := range ms {
+			ext = ext.union(d.Extent[m])
+			if b, ok := cfgBBox[m]; ok {
+				ext = ext.union(b)
+			}
+		}
+		d.Groups = append(d.Groups, GroupSpec{Members: ms, Overlays: over, Extent: ext})
+	}
+	// biggest first. groups.py's tie order is Python set-hash arbitrary;
+	// first-member key is the deterministic stand-in.
+	sort.SliceStable(d.Groups, func(i, j int) bool {
+		if len(d.Groups[i].Members) != len(d.Groups[j].Members) {
+			return len(d.Groups[i].Members) > len(d.Groups[j].Members)
+		}
+		return d.Groups[i].Members[0] < d.Groups[j].Members[0]
+	})
+	return d, nil
+}
+
+// groupLabels — display names, prose only. Ported as DATA from
+// groups.py: the membership is measured, and no entry here can add a
+// feed to a group or take one out. A component with no label is named
+// after its largest member.
+var groupLabels = map[string]string{
+	"mta-subway":                         "Northeast Corridor",
+	"sf-bay-area-rg":                     "Northern California",
+	"chicago-cta":                        "Chicago",
+	"wmata":                              "Washington–Baltimore",
+	"dallasarearapidtransit":             "Dallas–Fort Worth",
+	"gotransit":                          "Golden Horseshoe",
+	"socitdetransportdemontral":          "Montréal",
+	"exo-reseaudetransportmetropolitain": "Montréal",
+	"tri-rail":                           "South Florida",
+	"brightline-trails":                  "South Florida",
+	"mts":                                "San Diego",
+	"soundtransit":                       "Puget Sound",
+	"boston":                             "Greater Boston",
+	"barcelona-tmb":                      "Barcelona",
+	"tokyo-metro":                        "Tokyo",
+	"toei":                               "Tokyo",
+	"riometroregionaltransitdistrict":    "Rio Grande",
+	"floridadepartmentoftransportation":  "Central Florida",
+	"uta":                                "Wasatch Front",
+	"rtd":                                "Denver",
+	"trimet":                             "Portland",
+	"nstranslinkca":                      "Vancouver",
+	"atlanta":                            "Atlanta",
+	"charlotte":                          "Charlotte",
+	"rta":                                "Cleveland",
+	"metrostlouis":                       "St. Louis",
+}
+
+// slugify mirrors groups.py's slug(): NFKD-fold accents to ASCII, keep
+// alphanumerics, turn space/dash/en-dash/underscore into "-", collapse.
+// The stdlib has no NFKD, so the fold is a table over the Latin accents
+// that actually occur in labels and feed names; anything outside it is
+// dropped exactly as Python drops unfoldable characters.
+func slugify(name string) string {
+	var b strings.Builder
+	for _, ch := range strings.ToLower(name) {
+		if f, ok := latinFold[ch]; ok {
+			ch = f
+		}
+		switch {
+		case ch == ' ' || ch == '-' || ch == '_' || ch == '–': // groups.py: " -–_"
+			b.WriteByte('-')
+		case ch < 128 && (ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9'):
+			b.WriteRune(ch)
+		}
+	}
+	parts := strings.Split(b.String(), "-")
+	out := parts[:0]
+	for _, p := range parts {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return strings.Join(out, "-")
+}
+
+// latinFold: the NFKD-decompose-and-drop-marks result for the accented
+// Latin letters group labels and feed names use (lowercased input).
+var latinFold = map[rune]rune{
+	'à': 'a', 'á': 'a', 'â': 'a', 'ã': 'a', 'ä': 'a', 'å': 'a',
+	'ç': 'c', 'è': 'e', 'é': 'e', 'ê': 'e', 'ë': 'e',
+	'ì': 'i', 'í': 'i', 'î': 'i', 'ï': 'i', 'ñ': 'n',
+	'ò': 'o', 'ó': 'o', 'ô': 'o', 'õ': 'o', 'ö': 'o',
+	'ù': 'u', 'ú': 'u', 'û': 'u', 'ü': 'u', 'ý': 'y', 'ÿ': 'y',
+}

--- a/internal/sync/groups_test.go
+++ b/internal/sync/groups_test.go
@@ -1,0 +1,363 @@
+package sync
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/alexwohlbruck/portolan/internal/registry"
+)
+
+// The synthetic workspace: nine miniature feeds engineered to trip every
+// rule exactly once, at lat 40–42 where a lon degree is ~85 km.
+//
+//	a,b — share a 2.6 km corridor (≥900 m) → one group, members
+//	c,d — overlap only ~300 m (<900 m) → no pair, no group
+//	e,f — f is 95% of e (>85% of BOTH) → duplicate, f held out
+//	g   — corridor-scale (~40 deg² of shapes) riding a's corridor AND
+//	      h's → overlay on two components, member of neither
+//	h   — regional feed sharing steel with g only → lone member with an
+//	      overlay riding it (the Hartford Line case)
+//	u   — rides a's corridor but has no build → undrawn, held out
+//
+// a's configured bbox is WIDER than its shape extent — the Charlotte
+// rule: the group window must take the bbox, not just the shapes.
+
+type pt = [2]float64
+
+func seg(x0, x1, y float64) []pt  { return []pt{{x0, y}, {x1, y}} }
+func vseg(x, y0, y1 float64) []pt { return []pt{{x, y0}, {x, y1}} }
+
+type fxFeed struct {
+	name   string
+	shapes [][]pt
+	bbox   []float64
+	drawn  bool
+}
+
+func fixtureFeeds() (order []string, feeds map[string]fxFeed) {
+	corridorA := seg(-100.00, -99.95, 40.00) // ~4.3 km
+	corridorH := seg(-80.00, -79.96, 42.00)  // ~3.3 km
+	feeds = map[string]fxFeed{
+		"a": {"Alpha Transit", [][]pt{corridorA, vseg(-100.00, 40.00, 40.05)},
+			[]float64{-100.2, 39.9, -99.9, 40.1}, true},
+		"b": {"Beta Rail", [][]pt{seg(-100.00, -99.97, 40.00), vseg(-99.97, 40.00, 40.04)},
+			[]float64{-100.01, 39.99, -99.96, 40.05}, true},
+		"c": {"Charlie Line", [][]pt{seg(-100.50, -100.485, 40.30)},
+			[]float64{-100.51, 40.29, -100.48, 40.31}, true},
+		"d": {"Delta Line", [][]pt{seg(-100.4885, -100.47, 40.30)},
+			[]float64{-100.50, 40.29, -100.46, 40.31}, true},
+		"e": {"Echo Metro", [][]pt{seg(-101.00, -100.96, 40.20)},
+			[]float64{-101.01, 40.19, -100.95, 40.21}, true},
+		"f": {"Foxtrot Metro", [][]pt{seg(-101.00, -100.962, 40.20)},
+			[]float64{-101.01, 40.19, -100.955, 40.21}, true},
+		"g": {"Golf Corridor", [][]pt{corridorA, corridorH},
+			[]float64{-101, 38, -79, 43}, true},
+		"h": {"Hotel Metro", [][]pt{corridorH, vseg(-80.00, 42.00, 42.03)},
+			[]float64{-80.01, 41.99, -79.95, 42.04}, true},
+		"u": {"Uniform Railway", [][]pt{seg(-100.00, -99.975, 40.00)},
+			[]float64{-100.01, 39.99, -99.97, 40.01}, false},
+	}
+	return []string{"a", "b", "c", "d", "e", "f", "g", "h", "u"}, feeds
+}
+
+func ff(x float64) string { return strconv.FormatFloat(x, 'f', -1, 64) }
+
+// writeGTFSZip writes the three tables groups.py reads: one rail route,
+// one trip per shape.
+func writeGTFSZip(t *testing.T, path string, shapes [][]pt) {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	add := func(name, body string) {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	add("routes.txt", "route_id,route_type\nr1,2\n")
+	trips := "route_id,service_id,trip_id,shape_id\n"
+	shp := "shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence\n"
+	for i, poly := range shapes {
+		sid := fmt.Sprintf("s%d", i)
+		trips += fmt.Sprintf("r1,wk,t%d,%s\n", i, sid)
+		for j, p := range poly {
+			shp += fmt.Sprintf("%s,%s,%s,%d\n", sid, ff(p[1]), ff(p[0]), j)
+		}
+	}
+	add("trips.txt", trips)
+	add("shapes.txt", shp)
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// buildFixture materializes the workspace in dir (which becomes the
+// cwd): gtfs/<k>.zip, build/<k>.geojson for drawn feeds, portolan.json.
+// Returns the registry bytes.
+func buildFixture(t *testing.T, dir string) []byte {
+	t.Helper()
+	order, feeds := fixtureFeeds()
+	for _, sub := range []string{"gtfs", "build"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	doc := NewObj()
+	doc.Set("sketches", "sketches")
+	fo := NewObj()
+	for _, k := range order {
+		f := feeds[k]
+		writeGTFSZip(t, filepath.Join(dir, "gtfs", k+".zip"), f.shapes)
+		if f.drawn {
+			if err := os.WriteFile(filepath.Join(dir, "build", k+".geojson"),
+				bytes.Repeat([]byte("x"), 4000), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		e := NewObj()
+		e.Set("name", f.name)
+		e.Set("gtfs", "gtfs/"+k+".zip")
+		e.Set("out", "build/"+k+".geojson")
+		e.Set("bbox", []any{f.bbox[0], f.bbox[1], f.bbox[2], f.bbox[3]})
+		fo.Set(k, e)
+	}
+	doc.Set("feeds", fo)
+	raw := MarshalDoc(doc)
+	if err := os.WriteFile(filepath.Join(dir, "portolan.json"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func loadFixture(t *testing.T, raw []byte) (registry.Config, *Obj) {
+	t.Helper()
+	cfg, err := registry.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := ParseDoc(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg, doc
+}
+
+func TestDeriveGroupsRules(t *testing.T) {
+	dir := t.TempDir()
+	raw := buildFixture(t, dir)
+	t.Chdir(dir)
+	cfg, _ := loadFixture(t, raw)
+
+	d, err := DeriveGroups(cfg, nil, "build", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"a", "b", "c", "d", "e", "f", "g", "h", "u"}
+	if !reflect.DeepEqual(d.Measured, want) {
+		t.Fatalf("measured = %v", d.Measured)
+	}
+	// the ≥900 m floor: a‖b qualifies, c‖d (≈300 m) does not
+	if d.SharedM("a", "b") < minSharedM {
+		t.Fatalf("a‖b shared %.0f m, want ≥900", d.SharedM("a", "b"))
+	}
+	if d.SharedM("c", "d") != 0 {
+		t.Fatalf("c‖d shared %.0f m, want below the floor", d.SharedM("c", "d"))
+	}
+	// duplicates: f is e again (>85%% of BOTH lengths), smaller held out
+	if !reflect.DeepEqual(d.Duplicate, map[string]string{"f": "e"}) {
+		t.Fatalf("duplicates = %v", d.Duplicate)
+	}
+	// undrawn: u has no build ≥3000 bytes
+	if !reflect.DeepEqual(d.Undrawn, []string{"u"}) {
+		t.Fatalf("undrawn = %v", d.Undrawn)
+	}
+	// two groups: {a,b}+g, and the lone member h with the overlay riding
+	// it; e stands alone (its only partner was a duplicate), c and d
+	// never paired, u is held out of both roles
+	if len(d.Groups) != 2 {
+		t.Fatalf("groups = %+v", d.Groups)
+	}
+	g1, g2 := d.Groups[0], d.Groups[1]
+	if !reflect.DeepEqual(g1.Members, []string{"a", "b"}) ||
+		!reflect.DeepEqual(g1.Overlays, []string{"g"}) {
+		t.Fatalf("group 1 = %+v", g1)
+	}
+	if !reflect.DeepEqual(g2.Members, []string{"h"}) ||
+		!reflect.DeepEqual(g2.Overlays, []string{"g"}) {
+		t.Fatalf("group 2 = %+v", g2)
+	}
+	// overlay role by extent: g's shapes cover ~40 deg²
+	if a := d.Extent["g"].Area(); a <= maxMemberArea {
+		t.Fatalf("g area = %.1f, want corridor-scale", a)
+	}
+	// the Charlotte rule: a's configured bbox is wider than its shapes,
+	// and the group window must take the union of both
+	if g1.Extent != (Extent{-100.2, 39.9, -99.9, 40.1}) {
+		t.Fatalf("group 1 window = %v — configured bbox must widen it", g1.Extent)
+	}
+	if g2.Extent != (Extent{-80.01, 41.99, -79.95, 42.04}) {
+		t.Fatalf("group 2 window = %v", g2.Extent)
+	}
+}
+
+func TestRewriteGroupsShape(t *testing.T) {
+	dir := t.TempDir()
+	raw := buildFixture(t, dir)
+	t.Chdir(dir)
+	cfg, doc := loadFixture(t, raw)
+	d, err := DeriveGroups(cfg, nil, "build", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := RewriteGroups(doc, d, nil)
+	if !reflect.DeepEqual(keys, []string{"alpha-transit", "hotel-metro"}) {
+		t.Fatalf("group keys = %v", keys)
+	}
+	feeds := feedsObj(doc)
+	v, _ := feeds.Get("alpha-transit")
+	e := v.(*Obj)
+	if got := e.Str("gtfs"); got != "gtfs/a.zip,gtfs/b.zip,gtfs/g.zip" {
+		t.Fatalf("group gtfs = %q", got)
+	}
+	if got := MarshalDoc(mustGet(t, e, "bbox")); string(got) != "[\n  -100.23,\n  39.87,\n  -99.87,\n  40.13\n]" {
+		t.Fatalf("group bbox = %s", got)
+	}
+	if b, _ := e.m["derived"].(bool); !b {
+		t.Fatal("group entry must be derived")
+	}
+	if e.Str("chart_args") != chartArgsGroup {
+		t.Fatalf("chart_args = %q", e.Str("chart_args"))
+	}
+
+	// idempotence: deriving over the rewritten registry keeps key, name
+	// and members, and a second rewrite is a no-op byte for byte
+	raw2 := MarshalDoc(doc)
+	cfg2, doc2 := loadFixture(t, raw2)
+	d2, err := DeriveGroups(cfg2, nil, "build", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys2 := RewriteGroups(doc2, d2, nil)
+	if !reflect.DeepEqual(keys2, keys) {
+		t.Fatalf("rewrite not stable: %v then %v", keys, keys2)
+	}
+	if raw3 := MarshalDoc(doc2); !bytes.Equal(raw2, raw3) {
+		t.Fatalf("rewrite not idempotent:\n%s\n----\n%s", raw2, raw3)
+	}
+}
+
+func mustGet(t *testing.T, o *Obj, k string) any {
+	t.Helper()
+	v, ok := o.Get(k)
+	if !ok {
+		t.Fatalf("missing %q", k)
+	}
+	return v
+}
+
+// TestPythonParity runs tools/groups.py --write over the same synthetic
+// workspace and demands the Go rewrite produce byte-identical
+// portolan.json — members, overlays, windows, key order, formatting,
+// everything. This is the credibility of the whole patch feature.
+func TestPythonParity(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	groupsPy, err := filepath.Abs("../../tools/groups.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(groupsPy); err != nil {
+		t.Skipf("tools/groups.py not found: %v", err)
+	}
+
+	dir := t.TempDir()
+	raw := buildFixture(t, dir)
+	t.Chdir(dir)
+
+	// Go derivation + rewrite, in memory
+	cfg, doc := loadFixture(t, raw)
+	d, err := DeriveGroups(cfg, nil, "build", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	RewriteGroups(doc, d, nil)
+	goBytes := MarshalDoc(doc)
+
+	// the Python original, on disk
+	cmd := exec.Command("python3", groupsPy, "--write")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("groups.py: %v\n%s", err, out)
+	}
+	pyBytes, err := os.ReadFile(filepath.Join(dir, "portolan.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(goBytes, pyBytes) {
+		t.Fatalf("Go rewrite diverges from groups.py --write.\npython:\n%s\n\ngo:\n%s\n\n(groups.py said: %s)",
+			pyBytes, goBytes, out)
+	}
+}
+
+// TestMarshalDocMatchesPythonDumps re-serializes the repo's real
+// registry and checks it against python3's json.dumps(indent=2) — the
+// exact formatter every groups.py --write has used on it.
+func TestMarshalDocMatchesPythonDumps(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	regPath, err := filepath.Abs("../../portolan.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(regPath)
+	if err != nil {
+		t.Skipf("no repo portolan.json: %v", err)
+	}
+	doc, err := ParseDoc(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	goBytes := MarshalDoc(doc)
+	cmd := exec.Command("python3", "-c",
+		"import json,sys; sys.stdout.write(json.dumps(json.load(open(sys.argv[1])), indent=2))",
+		regPath)
+	pyBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("python3: %v", err)
+	}
+	if !bytes.Equal(goBytes, pyBytes) {
+		i := 0
+		for i < len(goBytes) && i < len(pyBytes) && goBytes[i] == pyBytes[i] {
+			i++
+		}
+		lo, hi := i-80, i+80
+		if lo < 0 {
+			lo = 0
+		}
+		clip := func(b []byte) string {
+			h := hi
+			if h > len(b) {
+				h = len(b)
+			}
+			return string(b[lo:h])
+		}
+		t.Fatalf("MarshalDoc diverges from json.dumps at byte %d:\npython: …%s…\ngo:     …%s…",
+			i, clip(pyBytes), clip(goBytes))
+	}
+}

--- a/internal/sync/plan.go
+++ b/internal/sync/plan.go
@@ -1,0 +1,443 @@
+package sync
+
+// The patch planner: given the registry, the state manifest and the
+// changed feed keys C, work out the closure of "input set changed"
+// (docs/SYNC.md) and say exactly what would rebuild. The executor
+// (phase 3) walks the Plan; --dry-run prints it.
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/alexwohlbruck/portolan/internal/registry"
+)
+
+// Plan is one sync run's work order. All lists are sorted feed/group
+// keys. Nothing here has happened yet — a Plan is a statement about
+// inputs, produced identically by patch and global (patch just measures
+// fewer feeds to get there).
+type Plan struct {
+	Changed  []string // C — feeds whose zip content moved
+	Measured []string // feeds whose shapes were read (the bbox-prefiltered closure)
+	Affected []string // C ∪ steel neighbors ∪ previous co-members/overlays
+
+	Standalone []string // rebuild their own builds: affected feeds no group absorbs
+	// MemberPyramids: changed feeds absorbed by a surviving group — the
+	// group draws them in the world, but their per-feed pyramid rebuilds
+	// because their own zip changed.
+	MemberPyramids []string
+	Groups         []string // group builds to run (created + modified + input-changed)
+	GroupsCreated  []string
+	GroupsDeleted  []string
+	// Overlays: wide feeds whose BACKGROUND build rebuilds — their zip
+	// changed, or a group window they cede moved under them.
+	Overlays []string
+
+	RegistryChanged bool
+	// Registry: the rewritten portolan.json payload (exactly what
+	// groups.py --write would have produced), nil when nothing moved.
+	Registry []byte
+
+	Derivation *Derivation // the measurement, for reporting
+}
+
+// PlanOpts wires one planning run.
+type PlanOpts struct {
+	Config   registry.Config
+	Doc      *Obj   // the same file, order-preserved (LoadDoc)
+	State    *State // the manifest; the planner reads nothing from it today, the executor stamps it
+	Changed  []string
+	BuildDir string
+	// Global measures every feed with a zip on disk instead of the bbox
+	// closure of Changed. With Global, Changed may be nil — it defaults
+	// to every measurable feed.
+	Global bool
+	Log    func(format string, a ...any)
+}
+
+// BuildPlan measures, re-derives group membership over the affected
+// component(s), diffs against the registry, and returns the Plan.
+func BuildPlan(o PlanOpts) (*Plan, error) {
+	logf := o.Log
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	cfg := o.Config
+
+	// C: validated feed keys. A group key is not a feed whose zip can
+	// change — its inputs are its members' zips. And a changed feed's
+	// zip must be ON DISK: C means "this zip's content moved", and
+	// planning group dissolution from an absent zip would read a partial
+	// data tree as the railway vanishing.
+	for _, k := range o.Changed {
+		fc, ok := cfg.Feeds[k]
+		if !ok {
+			return nil, fmt.Errorf("--feeds %s: not in the registry", k)
+		}
+		if len(fc.Members) > 0 {
+			return nil, fmt.Errorf("--feeds %s: a group, not a feed — name its members", k)
+		}
+		if zip := fc.PrimaryGTFS(); zip != "" {
+			if _, err := os.Stat(zip); err != nil {
+				return nil, fmt.Errorf("%s: %s is not on disk — a changed feed's zip must be present (run sync check first)", k, zip)
+			}
+		}
+	}
+	changed := dedupSort(o.Changed)
+
+	// measurable: non-group feeds whose primary zip exists
+	measurable := map[string]bool{}
+	for k, fc := range cfg.Feeds {
+		if len(fc.Members) > 0 {
+			continue
+		}
+		zip := fc.PrimaryGTFS()
+		if zip == "" {
+			continue
+		}
+		if _, err := os.Stat(zip); err == nil {
+			measurable[k] = true
+		}
+	}
+
+	var only map[string]bool
+	if o.Global {
+		if len(changed) == 0 {
+			for k := range measurable {
+				changed = append(changed, k)
+			}
+			sort.Strings(changed)
+		}
+	} else {
+		only = closureByWindow(cfg, measurable, changed)
+		logf("bbox prefilter: measuring %d of %d feeds", len(only), len(measurable))
+	}
+
+	der, err := DeriveGroups(cfg, only, o.BuildDir, logf)
+	if err != nil {
+		return nil, err
+	}
+
+	inC := map[string]bool{}
+	for _, k := range changed {
+		inC[k] = true
+	}
+
+	// affected: C, plus feeds sharing steel with C now, plus everyone a
+	// pre-existing group ties to a feed in C (a feed can LEAVE a group
+	// only because a zip in that group changed, and the leaver must then
+	// get a standalone build).
+	affected := map[string]bool{}
+	for k := range inC {
+		affected[k] = true
+	}
+	for p := range der.Pairs {
+		if inC[p[0]] {
+			affected[p[1]] = true
+		}
+		if inC[p[1]] {
+			affected[p[0]] = true
+		}
+	}
+	for _, fc := range cfg.Feeds {
+		if len(fc.Members) == 0 {
+			continue
+		}
+		tied := append(append([]string(nil), fc.Members...), fc.Overlays...)
+		touches := false
+		for _, m := range tied {
+			if inC[m] {
+				touches = true
+				break
+			}
+		}
+		if touches {
+			for _, m := range tied {
+				affected[m] = true
+			}
+		}
+	}
+
+	// group-scope derivation: only the derived groups touching an
+	// affected feed take part in the diff — the rest of the world is
+	// out of scope for a patch (and identical anyway for global).
+	scoped := &Derivation{
+		Length: der.Length, Pairs: der.Pairs, Extent: der.Extent,
+		Duplicate: der.Duplicate, Undrawn: der.Undrawn, Measured: der.Measured,
+	}
+	var scope map[string]bool
+	if !o.Global {
+		scope = affected
+	}
+	for _, g := range der.Groups {
+		if scope == nil {
+			scoped.Groups = append(scoped.Groups, g)
+			continue
+		}
+		for _, m := range g.Members {
+			if scope[m] {
+				scoped.Groups = append(scoped.Groups, g)
+				break
+			}
+		}
+	}
+
+	// rewrite on a clone; diff the group entries entry-by-entry
+	before := o.Doc
+	after := o.Doc.Clone()
+	kept := RewriteGroups(after, scoped, scope)
+
+	beforeFeeds := feedsObj(before)
+	afterFeeds := feedsObj(after)
+	entryBytes := func(f *Obj, k string) []byte {
+		if v, ok := f.Get(k); ok {
+			return MarshalDoc(v)
+		}
+		return nil
+	}
+	plan := &Plan{Changed: changed, Measured: der.Measured, Derivation: der}
+	keptSet := map[string]bool{}
+	groupInputs := map[string][]string{} // key → member+overlay feeds (kept is 1:1 with scoped.Groups)
+	for i, k := range kept {
+		keptSet[k] = true
+		g := scoped.Groups[i]
+		groupInputs[k] = append(groupInputs[k], g.Members...)
+		groupInputs[k] = append(groupInputs[k], g.Overlays...)
+	}
+	groupRebuild := map[string]bool{}
+	for k := range keptSet {
+		b := entryBytes(beforeFeeds, k)
+		switch {
+		case b == nil:
+			plan.GroupsCreated = append(plan.GroupsCreated, k)
+			groupRebuild[k] = true
+			plan.RegistryChanged = true
+		case string(b) != string(entryBytes(afterFeeds, k)):
+			groupRebuild[k] = true
+			plan.RegistryChanged = true
+		default:
+			// unchanged shape — rebuilds only when an input zip changed
+			for _, m := range groupInputs[k] {
+				if inC[m] {
+					groupRebuild[k] = true
+					break
+				}
+			}
+		}
+	}
+	// deleted: derived entries in scope that the data no longer supports
+	for _, k := range beforeFeeds.Keys() {
+		if keptSet[k] || afterFeeds.Has(k) {
+			continue
+		}
+		plan.GroupsDeleted = append(plan.GroupsDeleted, k)
+		plan.RegistryChanged = true
+	}
+	sort.Strings(plan.GroupsDeleted)
+	if plan.RegistryChanged {
+		plan.Registry = MarshalDoc(after)
+	}
+
+	// roles after the rewrite
+	memberAfter := map[string]bool{}
+	overlayAfter := map[string]bool{}
+	for _, g := range scoped.Groups {
+		for _, m := range g.Members {
+			memberAfter[m] = true
+		}
+		for _, ov := range g.Overlays {
+			overlayAfter[ov] = true
+		}
+	}
+	// members/overlays of untouched surviving groups still count
+	for _, k := range afterFeeds.Keys() {
+		e, _ := afterFeeds.Get(k)
+		eo, ok := e.(*Obj)
+		if !ok || !eo.Has("members") {
+			continue
+		}
+		for _, m := range strsOf(eo, "members") {
+			memberAfter[m] = true
+		}
+		for _, ov := range strsOf(eo, "overlays") {
+			overlayAfter[ov] = true
+		}
+	}
+	overlayBefore := map[string]bool{}
+	for _, k := range beforeFeeds.Keys() {
+		e, _ := beforeFeeds.Get(k)
+		if eo, ok := e.(*Obj); ok {
+			for _, ov := range strsOf(eo, "overlays") {
+				overlayBefore[ov] = true
+			}
+		}
+	}
+
+	// overlay backgrounds: zip changed, or the exclude-window set moved
+	overlaySet := map[string]bool{}
+	for ov := range overlayAfter {
+		if inC[ov] {
+			overlaySet[ov] = true
+			continue
+		}
+		if excludeWindows(beforeFeeds, ov) != excludeWindows(afterFeeds, ov) {
+			overlaySet[ov] = true
+		}
+	}
+	for ov := range overlayBefore {
+		if !overlayAfter[ov] && (inC[ov] ||
+			excludeWindows(beforeFeeds, ov) != excludeWindows(afterFeeds, ov)) {
+			overlaySet[ov] = true // it ceded windows it no longer cedes
+		}
+	}
+
+	for k := range affected {
+		plan.Affected = append(plan.Affected, k)
+		if memberAfter[k] {
+			if inC[k] {
+				plan.MemberPyramids = append(plan.MemberPyramids, k)
+			}
+			continue
+		}
+		if overlayAfter[k] || overlayBefore[k] {
+			continue // background rebuilds ride the overlay rule
+		}
+		plan.Standalone = append(plan.Standalone, k)
+	}
+	sort.Strings(plan.Affected)
+	sort.Strings(plan.Standalone)
+	sort.Strings(plan.MemberPyramids)
+	for k := range groupRebuild {
+		plan.Groups = append(plan.Groups, k)
+	}
+	sort.Strings(plan.Groups)
+	sort.Strings(plan.GroupsCreated)
+	for ov := range overlaySet {
+		plan.Overlays = append(plan.Overlays, ov)
+	}
+	sort.Strings(plan.Overlays)
+	return plan, nil
+}
+
+// closureByWindow: the bbox prefilter (docs/SYNC.md) — only feeds whose
+// window intersects a changed feed's window are measured, transitively
+// through REGION-scale windows, so a whole shared-steel component is
+// always measured together (two feeds sharing steel have overlapping
+// windows, and a member chain is a window chain). Corridor-scale
+// windows (area > maxMemberArea: Amtrak, VIA) are measured when touched
+// but do not propagate the frontier — they can never be members, and
+// letting them propagate would weld every patch into a global run. A
+// changed feed always propagates, whatever its size. A feed without a
+// configured bbox has an unknown window: it intersects everything and
+// propagates (this registry has none).
+func closureByWindow(cfg registry.Config, measurable map[string]bool,
+	changed []string) map[string]bool {
+	win := map[string]*Extent{}
+	for k := range measurable {
+		if b := cfg.Feeds[k].BBox; len(b) == 4 {
+			win[k] = &Extent{b[0], b[1], b[2], b[3]}
+		} else {
+			win[k] = nil // unknown window: intersects everything
+		}
+	}
+	inC := map[string]bool{}
+	for _, k := range changed {
+		inC[k] = true
+	}
+	propagates := func(k string) bool {
+		return inC[k] || win[k] == nil || win[k].Area() <= maxMemberArea
+	}
+	hits := func(a, b *Extent) bool {
+		if a == nil || b == nil {
+			return true
+		}
+		return a.Intersects(*b)
+	}
+	s := map[string]bool{}
+	for _, k := range changed {
+		if measurable[k] {
+			s[k] = true
+		}
+	}
+	for grew := true; grew; {
+		grew = false
+		for k := range measurable {
+			if s[k] {
+				continue
+			}
+			for in := range s {
+				if propagates(in) && hits(win[k], win[in]) {
+					s[k] = true
+					grew = true
+					break
+				}
+			}
+		}
+	}
+	return s
+}
+
+// excludeWindows: the serialized, order-free set of group bboxes that
+// cut territory out of an overlay's background build — the exclude-bbox
+// list feed.sh derives. Two equal strings mean the overlay's windows
+// did not move.
+func excludeWindows(feeds *Obj, overlay string) string {
+	var wins []string
+	for _, k := range feeds.Keys() {
+		v, _ := feeds.Get(k)
+		e, ok := v.(*Obj)
+		if !ok {
+			continue
+		}
+		found := false
+		for _, ov := range strsOf(e, "overlays") {
+			if ov == overlay {
+				found = true
+				break
+			}
+		}
+		if !found {
+			continue
+		}
+		if b, ok := e.Get("bbox"); ok {
+			wins = append(wins, string(MarshalDoc(b)))
+		}
+	}
+	sort.Strings(wins)
+	return fmt.Sprint(wins)
+}
+
+func feedsObj(doc *Obj) *Obj {
+	if v, ok := doc.Get("feeds"); ok {
+		if o, ok := v.(*Obj); ok {
+			return o
+		}
+	}
+	return NewObj()
+}
+
+func strsOf(e *Obj, field string) []string {
+	v, _ := e.Get(field)
+	arr, _ := v.([]any)
+	out := make([]string, 0, len(arr))
+	for _, x := range arr {
+		if s, ok := x.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func dedupSort(ss []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range ss {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/sync/plan.go
+++ b/internal/sync/plan.go
@@ -166,7 +166,13 @@ func BuildPlan(o PlanOpts) (*Plan, error) {
 		Length: der.Length, Pairs: der.Pairs, Extent: der.Extent,
 		Duplicate: der.Duplicate, Undrawn: der.Undrawn, Measured: der.Measured,
 	}
-	var scope map[string]bool
+	// scope bounds the delete rule: a derived group is deletable only if
+	// its members were measured. For patch that is the affected
+	// component; for global it is every feed with a zip on disk — a
+	// derived group whose members were never downloaded is out of scope,
+	// not unsupported (global operates on what is local, and an absent
+	// data tree must not read as the railway vanishing).
+	scope := measurable
 	if !o.Global {
 		scope = affected
 	}

--- a/internal/sync/plan_test.go
+++ b/internal/sync/plan_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"bytes"
+	"os"
 	"reflect"
 	"testing"
 
@@ -131,5 +132,48 @@ func TestBuildPlanGlobalMatchesPatchRegistry(t *testing.T) {
 	}
 	if !bytes.Equal(p2.Registry, global.Registry) {
 		t.Fatalf("patch(b)+patch(h) ≠ global:\n%s\n----\n%s", p2.Registry, global.Registry)
+	}
+}
+
+// TestBuildPlanGlobalKeepsAbsentGroups: global operates on what is
+// local — a derived group whose member zips were never downloaded is
+// out of scope, not unsupported, and must survive the rewrite.
+func TestBuildPlanGlobalKeepsAbsentGroups(t *testing.T) {
+	dir := t.TempDir()
+	raw := buildFixture(t, dir)
+	t.Chdir(dir)
+	cfg, doc := loadFixture(t, raw)
+
+	// settle the world: derive and rewrite both groups
+	d, err := DeriveGroups(cfg, nil, "build", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	RewriteGroups(doc, d, nil)
+	settled := MarshalDoc(doc)
+	cfg2, doc2 := loadFixture(t, settled)
+
+	// h's zip vanishes (never downloaded on this machine)
+	if err := os.Remove("gtfs/h.zip"); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := BuildPlan(PlanOpts{
+		Config: cfg2, Doc: doc2, State: &State{Feeds: map[string]FeedState{}},
+		BuildDir: "build", Global: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, g := range plan.GroupsDeleted {
+		if g == "hotel-metro" {
+			t.Fatal("global dissolved a group whose member zips are simply absent")
+		}
+	}
+	reg, err := registry.Parse(settled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reg.Feeds["hotel-metro"]; !ok {
+		t.Fatal("fixture lost hotel-metro before the check")
 	}
 }

--- a/internal/sync/plan_test.go
+++ b/internal/sync/plan_test.go
@@ -1,0 +1,135 @@
+package sync
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/alexwohlbruck/portolan/internal/registry"
+)
+
+func TestBuildPlanPatch(t *testing.T) {
+	dir := t.TempDir()
+	raw := buildFixture(t, dir)
+	t.Chdir(dir)
+	cfg, doc := loadFixture(t, raw)
+
+	plan, err := BuildPlan(PlanOpts{
+		Config: cfg, Doc: doc, State: &State{Feeds: map[string]FeedState{}},
+		Changed: []string{"b"}, BuildDir: "build",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// bbox prefilter: b's window touches a, u and the corridor g; h is
+	// reachable only THROUGH the corridor-scale g, which never
+	// propagates the frontier; c,d,e,f are far away
+	if !reflect.DeepEqual(plan.Measured, []string{"a", "b", "g", "u"}) {
+		t.Fatalf("measured = %v", plan.Measured)
+	}
+	if !reflect.DeepEqual(plan.Affected, []string{"a", "b", "g", "u"}) {
+		t.Fatalf("affected = %v", plan.Affected)
+	}
+	// a,b become a group: created, registry rewritten, b's own pyramid
+	if !reflect.DeepEqual(plan.Groups, []string{"alpha-transit"}) ||
+		!reflect.DeepEqual(plan.GroupsCreated, []string{"alpha-transit"}) ||
+		len(plan.GroupsDeleted) != 0 {
+		t.Fatalf("groups = %v created %v deleted %v",
+			plan.Groups, plan.GroupsCreated, plan.GroupsDeleted)
+	}
+	if !plan.RegistryChanged || len(plan.Registry) == 0 {
+		t.Fatal("registry rewrite expected")
+	}
+	// u is affected, absorbed by nothing → standalone; b is a member of
+	// the new group → pyramid only; g's exclude windows moved → background
+	if !reflect.DeepEqual(plan.Standalone, []string{"u"}) {
+		t.Fatalf("standalone = %v", plan.Standalone)
+	}
+	if !reflect.DeepEqual(plan.MemberPyramids, []string{"b"}) {
+		t.Fatalf("member pyramids = %v", plan.MemberPyramids)
+	}
+	if !reflect.DeepEqual(plan.Overlays, []string{"g"}) {
+		t.Fatalf("overlays = %v", plan.Overlays)
+	}
+	// the patch rewrite must NOT touch the out-of-scope component: h's
+	// group is not derived here, and nothing may be deleted for it
+	cfg2, err := registry.Parse(plan.Registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg2.Feeds["alpha-transit"]; !ok {
+		t.Fatal("rewritten registry lacks the new group")
+	}
+	if _, ok := cfg2.Feeds["h"]; !ok {
+		t.Fatal("rewritten registry lost an untouched feed")
+	}
+
+	// second run over the rewritten registry: the world is settled, so
+	// the same change now rebuilds the surviving group and nothing is
+	// created, deleted or rewritten
+	doc2, err := ParseDoc(plan.Registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan2, err := BuildPlan(PlanOpts{
+		Config: cfg2, Doc: doc2, State: &State{Feeds: map[string]FeedState{}},
+		Changed: []string{"b"}, BuildDir: "build",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan2.RegistryChanged {
+		t.Fatalf("second run rewrote the registry:\n%s", plan2.Registry)
+	}
+	if !reflect.DeepEqual(plan2.Groups, []string{"alpha-transit"}) ||
+		len(plan2.GroupsCreated) != 0 || len(plan2.GroupsDeleted) != 0 {
+		t.Fatalf("second run groups = %v created %v deleted %v",
+			plan2.Groups, plan2.GroupsCreated, plan2.GroupsDeleted)
+	}
+	if len(plan2.Overlays) != 0 {
+		t.Fatalf("second run overlays = %v — windows did not move", plan2.Overlays)
+	}
+	if !reflect.DeepEqual(plan2.MemberPyramids, []string{"b"}) {
+		t.Fatalf("second run member pyramids = %v", plan2.MemberPyramids)
+	}
+}
+
+func TestBuildPlanGlobalMatchesPatchRegistry(t *testing.T) {
+	dir := t.TempDir()
+	raw := buildFixture(t, dir)
+	t.Chdir(dir)
+	cfg, doc := loadFixture(t, raw)
+
+	global, err := BuildPlan(PlanOpts{
+		Config: cfg, Doc: doc, State: &State{Feeds: map[string]FeedState{}},
+		BuildDir: "build", Global: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// global derives BOTH groups and rewrites both into the registry
+	if !reflect.DeepEqual(global.GroupsCreated, []string{"alpha-transit", "hotel-metro"}) {
+		t.Fatalf("global created = %v", global.GroupsCreated)
+	}
+	// patch after b, then patch after h, must land the registry exactly
+	// where one global run lands it — the oracle
+	p1, err := BuildPlan(PlanOpts{
+		Config: cfg, Doc: doc, State: &State{Feeds: map[string]FeedState{}},
+		Changed: []string{"b"}, BuildDir: "build",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg2, _ := registry.Parse(p1.Registry)
+	doc2, _ := ParseDoc(p1.Registry)
+	p2, err := BuildPlan(PlanOpts{
+		Config: cfg2, Doc: doc2, State: &State{Feeds: map[string]FeedState{}},
+		Changed: []string{"h"}, BuildDir: "build",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(p2.Registry, global.Registry) {
+		t.Fatalf("patch(b)+patch(h) ≠ global:\n%s\n----\n%s", p2.Registry, global.Registry)
+	}
+}

--- a/internal/sync/regdoc.go
+++ b/internal/sync/regdoc.go
@@ -1,0 +1,295 @@
+package sync
+
+// The registry document, order-preserved. registry.Config parses
+// portolan.json into maps for the engine; rewriting GROUPS back needs
+// what maps throw away — key order — because groups.py --write emits
+// `json.dumps(cfg, indent=2)` over a dict that keeps file order, and the
+// whole point of a patch run's registry rewrite is a small diff. So this
+// file is an ordered JSON representation plus a serializer that matches
+// Python's json.dumps byte for byte: 2-space indent, ", "/": "
+// separators, ensure_ascii escapes, floats via repr, no trailing
+// newline.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Obj is a JSON object with remembered key order. Values are one of:
+// *Obj, []any, string, json.Number, bool, nil.
+type Obj struct {
+	keys []string
+	m    map[string]any
+}
+
+func NewObj() *Obj { return &Obj{m: map[string]any{}} }
+
+func (o *Obj) Keys() []string { return append([]string(nil), o.keys...) }
+
+func (o *Obj) Get(k string) (any, bool) { v, ok := o.m[k]; return v, ok }
+
+// Set keeps an existing key's position and appends a new one — dict
+// assignment semantics, which the rewrite relies on.
+func (o *Obj) Set(k string, v any) {
+	if _, ok := o.m[k]; !ok {
+		o.keys = append(o.keys, k)
+	}
+	o.m[k] = v
+}
+
+func (o *Obj) Delete(k string) {
+	if _, ok := o.m[k]; !ok {
+		return
+	}
+	delete(o.m, k)
+	for i, kk := range o.keys {
+		if kk == k {
+			o.keys = append(o.keys[:i], o.keys[i+1:]...)
+			break
+		}
+	}
+}
+
+func (o *Obj) Has(k string) bool { _, ok := o.m[k]; return ok }
+
+// Str returns a string value, "" when absent or not a string.
+func (o *Obj) Str(k string) string {
+	s, _ := o.m[k].(string)
+	return s
+}
+
+// Clone is a deep copy — the rewrite mutates entries and the planner
+// wants to diff against the original.
+func (o *Obj) Clone() *Obj {
+	c := NewObj()
+	for _, k := range o.keys {
+		c.Set(k, cloneVal(o.m[k]))
+	}
+	return c
+}
+
+func cloneVal(v any) any {
+	switch t := v.(type) {
+	case *Obj:
+		return t.Clone()
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = cloneVal(e)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// ParseDoc decodes JSON preserving object key order. Numbers stay
+// json.Number, so an untouched value re-emits with its source spelling.
+func ParseDoc(raw []byte) (*Obj, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	v, err := parseValue(dec)
+	if err != nil {
+		return nil, err
+	}
+	obj, ok := v.(*Obj)
+	if !ok {
+		return nil, fmt.Errorf("registry document is not a JSON object")
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("trailing data after registry document")
+	}
+	return obj, nil
+}
+
+// LoadDoc reads and parses a registry file order-preserved.
+func LoadDoc(path string) (*Obj, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	doc, err := ParseDoc(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return doc, nil
+}
+
+func parseValue(dec *json.Decoder) (any, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	switch t := tok.(type) {
+	case json.Delim:
+		switch t {
+		case '{':
+			o := NewObj()
+			for dec.More() {
+				kt, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				k, ok := kt.(string)
+				if !ok {
+					return nil, fmt.Errorf("object key is not a string")
+				}
+				v, err := parseValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				o.Set(k, v)
+			}
+			if _, err := dec.Token(); err != nil { // consume '}'
+				return nil, err
+			}
+			return o, nil
+		case '[':
+			arr := []any{}
+			for dec.More() {
+				v, err := parseValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, v)
+			}
+			if _, err := dec.Token(); err != nil { // consume ']'
+				return nil, err
+			}
+			return arr, nil
+		}
+		return nil, fmt.Errorf("unexpected delimiter %v", t)
+	default:
+		return tok, nil // string, json.Number, bool, nil
+	}
+}
+
+// MarshalDoc serializes exactly as Python's json.dumps(v, indent=2)
+// does — the format every groups.py --write has produced, so a Go
+// rewrite diffs only where the data moved.
+func MarshalDoc(v any) []byte {
+	var b bytes.Buffer
+	writeVal(&b, v, 0)
+	return b.Bytes()
+}
+
+func writeVal(b *bytes.Buffer, v any, depth int) {
+	switch t := v.(type) {
+	case nil:
+		b.WriteString("null")
+	case bool:
+		if t {
+			b.WriteString("true")
+		} else {
+			b.WriteString("false")
+		}
+	case string:
+		writePyString(b, t)
+	case json.Number:
+		b.WriteString(string(t))
+	case float64:
+		b.WriteString(pyFloat(t))
+	case int:
+		b.WriteString(strconv.Itoa(t))
+	case []any:
+		if len(t) == 0 {
+			b.WriteString("[]")
+			return
+		}
+		b.WriteString("[\n")
+		for i, e := range t {
+			ind(b, depth+1)
+			writeVal(b, e, depth+1)
+			if i < len(t)-1 {
+				b.WriteByte(',')
+			}
+			b.WriteByte('\n')
+		}
+		ind(b, depth)
+		b.WriteByte(']')
+	case *Obj:
+		if len(t.keys) == 0 {
+			b.WriteString("{}")
+			return
+		}
+		b.WriteString("{\n")
+		for i, k := range t.keys {
+			ind(b, depth+1)
+			writePyString(b, k)
+			b.WriteString(": ")
+			writeVal(b, t.m[k], depth+1)
+			if i < len(t.keys)-1 {
+				b.WriteByte(',')
+			}
+			b.WriteByte('\n')
+		}
+		ind(b, depth)
+		b.WriteByte('}')
+	default:
+		panic(fmt.Sprintf("regdoc: unhandled type %T", v))
+	}
+}
+
+func ind(b *bytes.Buffer, depth int) {
+	for i := 0; i < depth; i++ {
+		b.WriteString("  ")
+	}
+}
+
+// writePyString escapes like json.dumps with ensure_ascii=True: the
+// short escapes, \uXXXX for other control characters and everything
+// past 0x7E, surrogate pairs for astral codepoints.
+func writePyString(b *bytes.Buffer, s string) {
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\b':
+			b.WriteString(`\b`)
+		case '\f':
+			b.WriteString(`\f`)
+		default:
+			switch {
+			case r >= 0x20 && r <= 0x7E:
+				b.WriteByte(byte(r))
+			case r > 0xFFFF: // surrogate pair
+				r -= 0x10000
+				fmt.Fprintf(b, `\u%04x\u%04x`, 0xD800+(r>>10), 0xDC00+(r&0x3FF))
+			default:
+				fmt.Fprintf(b, `\u%04x`, r)
+			}
+		}
+	}
+	b.WriteByte('"')
+}
+
+// pyFloat formats a float the way Python's repr does for the magnitudes
+// a bbox holds: shortest round-trip decimal, and a trailing ".0" on
+// integral values ("40.0", where Go would say "40").
+func pyFloat(f float64) string {
+	s := strconv.FormatFloat(f, 'f', -1, 64)
+	if !strings.ContainsAny(s, ".eE") {
+		s += ".0"
+	}
+	return s
+}
+
+// round4 mirrors Python's round(x, 4): the correctly-rounded 4-decimal
+// value of the binary double.
+func round4(x float64) float64 {
+	v, _ := strconv.ParseFloat(strconv.FormatFloat(x, 'f', 4, 64), 64)
+	return v
+}

--- a/internal/sync/rewrite.go
+++ b/internal/sync/rewrite.go
@@ -1,0 +1,239 @@
+package sync
+
+// RewriteGroups — the Go port of groups.py's write(): fold a Derivation
+// back into the registry document. The document mutates exactly as the
+// Python original would have mutated its dict, so MarshalDoc of the
+// result is byte-comparable with a groups.py --write of the same data.
+
+import (
+	"sort"
+	"strings"
+)
+
+// chartArgsGroup: --allow-unmatched is not laxity, it is the clip. A
+// corridor feed cut at a group's window arrives as fragments, and a
+// fragment that is 100% gap would fail the whole document. Members are
+// still guarded by tools/groupverify.py, on ink rather than this gate.
+const chartArgsGroup = "--set match_gap_cost=150 --allow-unmatched"
+
+// RewriteGroups mutates doc's "feeds" to carry exactly der's groups:
+// updated entries keep their key, curated name and position; groups the
+// data no longer supports are deleted; new groups append. Returns the
+// kept group keys in write order.
+//
+// scope, when non-nil, bounds the DELETE rule to derived group entries
+// whose members intersect it — a patch run measures only the affected
+// component, and a group it did not measure is not thereby unsupported.
+// Nil scope is the global run: any derived entry not re-derived goes.
+//
+// The returned slice is keyed 1:1 with der.Groups: element i is the
+// registry key group i landed under.
+func RewriteGroups(doc *Obj, der *Derivation, scope map[string]bool) []string {
+	feedsV, _ := doc.Get("feeds")
+	feeds, ok := feedsV.(*Obj)
+	if !ok {
+		feeds = NewObj()
+		doc.Set("feeds", feeds)
+	}
+
+	entryOf := func(k string) *Obj {
+		if v, ok := feeds.Get(k); ok {
+			if o, ok := v.(*Obj); ok {
+				return o
+			}
+		}
+		return nil
+	}
+	membersOf := func(k string) []string {
+		e := entryOf(k)
+		if e == nil {
+			return nil
+		}
+		v, _ := e.Get("members")
+		arr, _ := v.([]any)
+		out := make([]string, 0, len(arr))
+		for _, m := range arr {
+			if s, ok := m.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	primaryGTFS := func(k string) string {
+		e := entryOf(k)
+		if e == nil {
+			return ""
+		}
+		return strings.TrimSpace(strings.Split(e.Str("gtfs"), ",")[0])
+	}
+
+	// a group entry the data once wrote — deletable if no longer supported
+	old := map[string]bool{}
+	for _, k := range feeds.Keys() {
+		e := entryOf(k)
+		if e == nil {
+			continue
+		}
+		if b, _ := e.m["derived"].(bool); !b {
+			continue
+		}
+		if scope != nil {
+			touches := false
+			for _, m := range membersOf(k) {
+				if scope[m] {
+					touches = true
+					break
+				}
+			}
+			if !touches {
+				continue
+			}
+		}
+		old[k] = true
+	}
+
+	keyOf := make([]string, 0, len(der.Groups))
+	var keptOrder []string
+	kept := map[string]*Obj{}
+	for _, g := range der.Groups {
+		// the label comes from whichever member has one, biggest first —
+		// the Northeast component's longest member is NJ Transit, which
+		// would have named the whole corridor after it
+		ranked := append([]string(nil), g.Members...)
+		sort.SliceStable(ranked, func(i, j int) bool {
+			return der.Length[ranked[i]] > der.Length[ranked[j]]
+		})
+		anchor := ranked[0]
+		for _, m := range ranked {
+			if _, ok := groupLabels[m]; ok {
+				anchor = m
+				break
+			}
+		}
+		inG := map[string]bool{}
+		for _, m := range g.Members {
+			inG[m] = true
+		}
+		// an existing group entry that already covers these members keeps
+		// its key, its curated name and its sketch — regrouping must not
+		// orphan style/chicago.json or a hand-drawn network
+		prev, prevOverlap := "", 0
+		for _, k := range feeds.Keys() {
+			n := 0
+			for _, m := range membersOf(k) {
+				if inG[m] {
+					n++
+				}
+			}
+			if n > 0 && (prev == "" || prevOverlap < n) {
+				prev, prevOverlap = k, n
+			}
+		}
+		var key, name string
+		if prev != "" {
+			key = prev
+			name = entryOf(prev).Str("name")
+			if name == "" {
+				name = groupLabels[anchor]
+				if name == "" {
+					name = anchor
+				}
+			}
+		} else {
+			name = groupLabels[anchor]
+			if name == "" {
+				name = entryOf(anchor).Str("name")
+				if name == "" {
+					name = anchor
+				}
+			}
+			key = slugify(name)
+			if feeds.Has(key) {
+				key += "-region"
+			}
+		}
+
+		var gtfs []string
+		seen := map[string]bool{}
+		for _, m := range append(append([]string(nil), g.Members...), g.Overlays...) {
+			p := primaryGTFS(m)
+			if !seen[p] {
+				seen[p] = true
+				gtfs = append(gtfs, p)
+			}
+		}
+
+		entry := NewObj()
+		if e := entryOf(key); e != nil {
+			entry = e.Clone()
+		}
+		orDefault := func(field, def string) string {
+			if v := entry.Str(field); v != "" {
+				return v
+			}
+			return def
+		}
+		entry.Set("name", name)
+		entry.Set("gtfs", strings.Join(gtfs, ","))
+		entry.Set("rail", orDefault("rail", "build/"+key+"-rail.geojson"))
+		entry.Set("stops", orDefault("stops", "build/"+key+"-stops.geojson"))
+		entry.Set("out", orDefault("out", "build/"+key+".geojson"))
+		entry.Set("bbox", []any{
+			round4(g.Extent[0] - marginDeg), round4(g.Extent[1] - marginDeg),
+			round4(g.Extent[2] + marginDeg), round4(g.Extent[3] + marginDeg)})
+		entry.Set("members", strList(g.Members))
+		// the corridor feeds charted into this window. Not members — they
+		// keep their own tileset everywhere else — but their CURATION has
+		// to ride in, or one railroad changes colour at the group's edge.
+		entry.Set("overlays", strList(g.Overlays))
+		entry.Set("derived", true)
+		entry.Set("chart_args", chartArgsGroup)
+		// A member built with a streets extract draws its BUSES; without
+		// one the group silently loses them. Members that share an extract
+		// resolve to one path; genuinely different ones are merged by
+		// groupbuild before the chart runs.
+		var st []string
+		stSeen := map[string]bool{}
+		for _, m := range g.Members {
+			if e := entryOf(m); e != nil {
+				if s := e.Str("streets"); s != "" && !stSeen[s] {
+					stSeen[s] = true
+					st = append(st, s)
+				}
+			}
+		}
+		switch {
+		case len(st) == 1:
+			entry.Set("streets", st[0])
+		case len(st) > 1:
+			entry.Set("streets", "build/"+key+"-streets.geojson")
+			entry.Set("streets_from", strList(st))
+		default:
+			entry.Delete("streets")
+			entry.Delete("streets_from")
+		}
+		if _, dup := kept[key]; !dup {
+			keptOrder = append(keptOrder, key)
+		}
+		kept[key] = entry
+		keyOf = append(keyOf, key)
+	}
+
+	for k := range old {
+		if _, ok := kept[k]; !ok {
+			feeds.Delete(k) // a group the data no longer supports
+		}
+	}
+	for _, k := range keptOrder {
+		feeds.Set(k, kept[k])
+	}
+	return keyOf
+}
+
+func strList(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}

--- a/internal/sync/run.go
+++ b/internal/sync/run.go
@@ -1,0 +1,469 @@
+package sync
+
+// The executor: walk a Plan for real. Registry first (the plan's
+// rewrite, atomically), then every build in the plan under --jobs
+// bounded parallelism, each as a `portolan chart` CHILD PROCESS — chart
+// configuration (style, tuning dials) is process state, so two builds
+// in one process would read each other's colours; a child per build is
+// also exactly how tools/feed.sh and groupbuild.sh have always run, and
+// it keeps one build's memory spike from another's. Group builds pass
+// the ink-retention gate (verify.go) before they are allowed to stand;
+// a failing group is DELETED from the registry, its pyramid removed,
+// and its members' standalone builds join the queue. After each
+// successful build the pyramid is cut in-process (tiles.Build is pure),
+// the resolved style manifest rides into the pyramid as style.json, and
+// the state manifest is stamped — incrementally, so an interrupted run
+// resumes where it stopped. One build's failure lands in Errors;
+// everything else proceeds.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	gosync "sync"
+
+	"github.com/alexwohlbruck/portolan/internal/registry"
+	"github.com/alexwohlbruck/portolan/internal/tiles"
+)
+
+// RunOpts wires one executor run. Portolan is the binary chart children
+// run as; empty means the current executable.
+type RunOpts struct {
+	ConfigPath string
+	StatePath  string
+	BuildDir   string
+	TilesDir   string
+	ExportDir  string // empty = skip export
+	StyleDir   string
+	Jobs       int    // ≤0 means DefaultJobs()
+	Portolan   string // chart child binary; "" = os.Executable()
+	Log        func(format string, a ...any)
+}
+
+// DefaultJobs is deliberately modest: chart holds a whole region in
+// memory, so NumCPU children of it would swap long before they'd scale.
+// The --jobs flag is authoritative when given.
+func DefaultJobs() int {
+	n := runtime.NumCPU()
+	if n > 4 {
+		n = 4
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// TileTally aggregates the differ stats across every pyramid touched.
+type TileTally struct {
+	Written   int `json:"written"`
+	Unchanged int `json:"unchanged"`
+	Removed   int `json:"removed"`
+}
+
+// RunResult is the machine-readable outcome — the RESULT line's body.
+type RunResult struct {
+	Changed         []string
+	Affected        []string
+	Rebuilt         []string // builds actually run (skips excluded)
+	GroupsRewritten bool
+	Tiles           TileTally
+	Exported        []string // "<feedkey>.zip" names present under ExportDir, flat
+	Errors          []string
+}
+
+// task kinds. Standalone, overlay and member builds are the feed's OWN
+// build and export their zips; a group build must not export — its
+// member zips belong to the members' own builds, and two builds writing
+// one export zip would race.
+const (
+	taskStandalone = "standalone"
+	taskOverlay    = "overlay"
+	taskMember     = "member-pyramid"
+	taskGroup      = "group"
+)
+
+type task struct {
+	key  string
+	kind string
+}
+
+// verifyGroupFn is the gate, swappable by tests to force a failure.
+var verifyGroupFn = verifyGroup
+
+// Run executes a Plan. The returned error is a run-level failure (a
+// registry that cannot be written, a state manifest that cannot be
+// read); per-build failures land in RunResult.Errors instead.
+func Run(plan *Plan, o RunOpts) (*RunResult, error) {
+	logf := o.Log
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	if o.Portolan == "" {
+		exe, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("resolving the portolan binary: %w", err)
+		}
+		o.Portolan = exe
+	}
+	jobs := o.Jobs
+	if jobs <= 0 {
+		jobs = DefaultJobs()
+	}
+
+	// the registry first: every build below reads it, and a crash after
+	// this write leaves a registry the next run re-plans from correctly
+	var raw []byte
+	if plan.RegistryChanged {
+		if err := atomicWrite(o.ConfigPath, plan.Registry); err != nil {
+			return nil, fmt.Errorf("writing the registry rewrite: %w", err)
+		}
+		raw = plan.Registry
+		logf("registry rewritten (%d bytes)", len(raw))
+	} else {
+		var err error
+		raw, err = os.ReadFile(o.ConfigPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	cfg, err := registry.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	doc, err := ParseDoc(raw)
+	if err != nil {
+		return nil, err
+	}
+	st, err := LoadState(o.StatePath)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &RunResult{
+		Changed:  emptyNotNil(plan.Changed),
+		Affected: emptyNotNil(plan.Affected),
+		Rebuilt:  []string{},
+		Exported: []string{},
+		Errors:   []string{},
+	}
+
+	// pyramids the plan retires: deleted groups no longer exist to draw.
+	// Member pyramids stay — the world index skips grouped members, but
+	// the atlas still serves their per-feed pyramids for feed-scoped
+	// viewing, and MemberPyramids rebuilds them when their zip changes.
+	for _, g := range plan.GroupsDeleted {
+		if err := os.RemoveAll(filepath.Join(o.TilesDir, g)); err != nil {
+			res.Errors = append(res.Errors, g+": removing pyramid: "+err.Error())
+		} else {
+			logf("%s: group dissolved — pyramid removed", g)
+		}
+		delete(st.Feeds, g)
+	}
+	if len(plan.GroupsDeleted) > 0 {
+		saveStateNow := st.Save(o.StatePath)
+		if saveStateNow != nil {
+			res.Errors = append(res.Errors, "state manifest: "+saveStateNow.Error())
+		}
+	}
+
+	var tasks []task
+	for _, k := range plan.Standalone {
+		tasks = append(tasks, task{k, taskStandalone})
+	}
+	for _, k := range plan.Overlays {
+		tasks = append(tasks, task{k, taskOverlay})
+	}
+	for _, k := range plan.MemberPyramids {
+		tasks = append(tasks, task{k, taskMember})
+	}
+	for _, k := range plan.Groups {
+		tasks = append(tasks, task{k, taskGroup})
+	}
+
+	var (
+		mu      gosync.Mutex // guards res, st, doc, cascades, built
+		built   = map[string]bool{}
+		cascade []task
+	)
+	saveState := func() {
+		if err := st.Save(o.StatePath); err != nil {
+			res.Errors = append(res.Errors, "state manifest: "+err.Error())
+		}
+	}
+	oops := func(key, what string, err error) {
+		mu.Lock()
+		res.Errors = append(res.Errors, key+": "+what+": "+err.Error())
+		mu.Unlock()
+		logf("%s: %s: %v", key, what, err)
+	}
+
+	runTask := func(t task) {
+		exportDir := o.ExportDir
+		if t.kind == taskGroup {
+			exportDir = ""
+		}
+		if t.kind == taskGroup {
+			if err := groupPreflight(cfg, t.key, o.BuildDir, logf); err != nil {
+				oops(t.key, "preflight", err)
+				return
+			}
+		}
+		spec, err := assembleChart(doc, cfg, t.key, o.BuildDir, o.StyleDir, exportDir, logf)
+		if err != nil {
+			oops(t.key, "assemble", err)
+			return
+		}
+		fp, err := fingerprintBuild(spec)
+		if err != nil {
+			oops(t.key, "fingerprint", err)
+			return
+		}
+		tileDir := filepath.Join(o.TilesDir, t.key)
+		mu.Lock()
+		row := st.Feeds[t.key]
+		mu.Unlock()
+		if row.Built == fp && row.Tiled == fp &&
+			(exportDir == "" || row.Exported == fp) &&
+			exists(spec.Out) && exists(filepath.Join(tileDir, "tiles.json")) &&
+			exists(filepath.Join(tileDir, "style.json")) {
+			logf("%s: clean (built, tiled%s) — skipped", t.key,
+				map[bool]string{true: ", exported", false: ""}[exportDir != ""])
+			return
+		}
+
+		logf("%s: chart (%s)", t.key, t.kind)
+		cmd := exec.Command(o.Portolan, append([]string{"chart"}, spec.Argv...)...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			oops(t.key, "build", fmt.Errorf("%v — %s", err, lastLine(out)))
+			return
+		}
+		mu.Lock()
+		row = st.Feeds[t.key]
+		row.Built = fp
+		if exportDir != "" {
+			row.Exported = fp
+		}
+		st.Feeds[t.key] = row
+		built[t.key] = true
+		res.Rebuilt = append(res.Rebuilt, t.key)
+		saveState()
+		mu.Unlock()
+
+		if t.kind == taskGroup {
+			v, err := verifyGroupFn(cfg, o.BuildDir, t.key)
+			if err != nil {
+				oops(t.key, "verify", err)
+				return
+			}
+			bad := strings.Join(v.Bad, ", ")
+			logf("%s: members retained %.1f%% of drawn ink%s", t.key, v.Worst*100,
+				map[bool]string{true: "  LOW: " + bad, false: ""}[len(v.Bad) > 0])
+			if !v.ok() {
+				// VERIFY FAILED — the group would take its members' ink off
+				// the map. Delete it, restore the members to standalone.
+				logf("%s: VERIFY FAILED (%s) — DROP: group deleted, members restored to standalone", t.key, bad)
+				mu.Lock()
+				feedsObj(doc).Delete(t.key)
+				res.GroupsRewritten = true
+				delete(st.Feeds, t.key)
+				if err := atomicWrite(o.ConfigPath, MarshalDoc(doc)); err != nil {
+					res.Errors = append(res.Errors, t.key+": rewriting registry after drop: "+err.Error())
+				}
+				res.Errors = append(res.Errors, t.key+": verify failed ("+bad+") — group dropped")
+				saveState()
+				for _, m := range cfg.Feeds[t.key].Members {
+					if !built[m] {
+						cascade = append(cascade, task{m, taskStandalone})
+					}
+				}
+				mu.Unlock()
+				if err := os.RemoveAll(filepath.Join(o.TilesDir, t.key)); err != nil {
+					oops(t.key, "removing pyramid", err)
+				}
+				return
+			}
+		}
+
+		stats, err := tiles.Build(tiles.Opts{Build: spec.Out, Out: tileDir, Name: t.key})
+		if err != nil {
+			oops(t.key, "tiles", err)
+			return
+		}
+		// the resolved style manifest rides into the pyramid: the tile
+		// consumer fetches <feed>/style.json (docs/SYNC.md tile contract)
+		sty, err := os.ReadFile(spec.Out + ".style.json")
+		if err != nil {
+			oops(t.key, "style manifest", err)
+			return
+		}
+		if err := atomicWrite(filepath.Join(tileDir, "style.json"), sty); err != nil {
+			oops(t.key, "style manifest", err)
+			return
+		}
+		mu.Lock()
+		res.Tiles.Written += stats.Tiles
+		res.Tiles.Unchanged += stats.Unchanged
+		res.Tiles.Removed += stats.Removed
+		row = st.Feeds[t.key]
+		row.Tiled = fp
+		st.Feeds[t.key] = row
+		saveState()
+		mu.Unlock()
+		logf("%s: %d tiles written, %d unchanged, %d pruned", t.key,
+			stats.Tiles, stats.Unchanged, stats.Removed)
+	}
+
+	// wave 1: everything the plan ordered. All builds are independent —
+	// inputs are zips and extracts, never another build's output — so
+	// standalone, overlay, member and group builds share one pool.
+	pool := func(ts []task) {
+		sem := make(chan struct{}, jobs)
+		var wg gosync.WaitGroup
+		for _, t := range ts {
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(t task) {
+				defer wg.Done()
+				defer func() { <-sem }()
+				runTask(t)
+			}(t)
+		}
+		wg.Wait()
+	}
+	pool(tasks)
+	// wave 2: members restored by a dropped group. Their standalone
+	// builds usually still stand from before the group absorbed them, in
+	// which case the clean-skip catches them in milliseconds.
+	if len(cascade) > 0 {
+		pool(cascade)
+	}
+
+	// the world index, static: composed by the SAME helper the atlas
+	// serves /api/tiles/index.json from, over the post-run registry (a
+	// verify drop has already left doc), so the two cannot drift
+	finalRaw := MarshalDoc(doc)
+	finalCfg, err := registry.Parse(finalRaw)
+	if err != nil {
+		return nil, err
+	}
+	idx := tiles.Index(finalCfg, func(k string) string {
+		return filepath.Join(o.TilesDir, k)
+	})
+	idxRaw, err := jsonMarshal(idx)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(o.TilesDir, 0o755); err != nil {
+		return nil, err
+	}
+	if err := atomicWrite(filepath.Join(o.TilesDir, "index.json"), idxRaw); err != nil {
+		return nil, fmt.Errorf("writing index.json: %w", err)
+	}
+	logf("index.json: %d feeds", len(idx))
+
+	if o.ExportDir != "" {
+		entries, err := os.ReadDir(o.ExportDir)
+		if err == nil {
+			for _, e := range entries {
+				if !e.IsDir() && strings.HasSuffix(e.Name(), ".zip") {
+					res.Exported = append(res.Exported, e.Name())
+				}
+			}
+			sort.Strings(res.Exported)
+		}
+	}
+	sort.Strings(res.Rebuilt)
+	sort.Strings(res.Errors)
+	res.GroupsRewritten = res.GroupsRewritten || plan.RegistryChanged
+	return res, nil
+}
+
+// fingerprintBuild is the identity a state stamp compares against: the
+// assembled argv (which folds in the entry, its window, the ceded
+// windows and the style layering) plus every input zip's content hash.
+// Style documents and extracts are deliberately OUTSIDE it — the
+// manifest covers the feed only, by design (docs/SYNC.md).
+func fingerprintBuild(spec *buildSpec) (string, error) {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s\x00", strings.Join(spec.Argv, "\x00"))
+	for _, z := range spec.Zips {
+		c, err := ContentHash(z)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(h, "%s\x00%s\x00", z, c)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func exists(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && st.Size() > 0
+}
+
+func lastLine(out []byte) string {
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if s := strings.TrimSpace(lines[i]); s != "" {
+			if len(s) > 200 {
+				s = s[:200]
+			}
+			return s
+		}
+	}
+	return "(no output)"
+}
+
+func emptyNotNil(ss []string) []string {
+	if ss == nil {
+		return []string{}
+	}
+	return ss
+}
+
+// atomicWrite: temp file in the same directory, then rename — a crash
+// mid-write leaves the previous file intact rather than a truncated one.
+func atomicWrite(path string, raw []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+	if _, err := tmp.Write(raw); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	return nil
+}
+
+// jsonMarshal matches what the atlas's json.NewEncoder(w).Encode(out)
+// sends over the wire: compact JSON plus a trailing newline, so the
+// static file and the live endpoint are byte-identical.
+func jsonMarshal(v any) ([]byte, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return append(raw, '\n'), nil
+}

--- a/internal/sync/run_test.go
+++ b/internal/sync/run_test.go
@@ -1,0 +1,706 @@
+package sync
+
+// Executor tests over REAL builds: three miniature feeds the actual
+// pipeline charts in milliseconds — m1 and m2 share 2.6 km of corridor
+// (so a group derives once their builds exist), m3 draws alone far
+// away. The headline test is the oracle from docs/SYNC.md: after a
+// single-feed change, `sync patch` must leave a tiles tree byte-
+// identical to a fresh `sync global` over the same inputs, while
+// rebuilding strictly less.
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	gosync "sync"
+	"testing"
+
+	"github.com/alexwohlbruck/portolan/internal/registry"
+	"github.com/alexwohlbruck/portolan/internal/tiles"
+)
+
+// ------------------------------------------------------------ binary
+
+var testBin struct {
+	once gosync.Once
+	path string
+	err  error
+}
+
+// portolanBin builds the real binary once per test run — the executor
+// charts through child processes, exactly as production does. Resolved
+// from this source file's location so t.Chdir cannot break it.
+func portolanBin(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not on PATH")
+	}
+	testBin.once.Do(func() {
+		dir, err := os.MkdirTemp("", "portolan-test-bin")
+		if err != nil {
+			testBin.err = err
+			return
+		}
+		_, thisFile, _, _ := runtime.Caller(0)
+		root := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+		bin := filepath.Join(dir, "portolan")
+		cmd := exec.Command("go", "build", "-o", bin, "./cmd/portolan")
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			testBin.err = fmt.Errorf("go build: %v\n%s", err, out)
+			return
+		}
+		testBin.path = bin
+	})
+	if testBin.err != nil {
+		t.Fatal(testBin.err)
+	}
+	return testBin.path
+}
+
+// ------------------------------------------------------ micro fixtures
+
+type microStop struct {
+	id, name string
+	lon, lat float64
+}
+
+// writeMicroGTFS writes a complete, chartable feed: one rail route,
+// three trips over one shape, timed stops.
+func writeMicroGTFS(t *testing.T, path, route string, stops []microStop, shape [][2]float64) {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	add := func(name, body string) {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	add("agency.txt", "agency_id,agency_name,agency_url,agency_timezone\na1,Micro,https://example.com,America/New_York\n")
+	add("routes.txt", fmt.Sprintf("route_id,agency_id,route_short_name,route_long_name,route_type\n%s,a1,%s,%s Line,2\n", route, route, route))
+	add("calendar.txt", "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\nwk,1,1,1,1,1,0,0,20250101,20261231\n")
+	var sb strings.Builder
+	sb.WriteString("stop_id,stop_name,stop_lat,stop_lon\n")
+	for _, s := range stops {
+		fmt.Fprintf(&sb, "%s,%s,%s,%s\n", s.id, s.name, ff(s.lat), ff(s.lon))
+	}
+	add("stops.txt", sb.String())
+	var shp strings.Builder
+	shp.WriteString("shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence\n")
+	for i, p := range shape {
+		fmt.Fprintf(&shp, "shp,%s,%s,%d\n", ff(p[1]), ff(p[0]), i)
+	}
+	add("shapes.txt", shp.String())
+	trips := "route_id,service_id,trip_id,shape_id\n"
+	st := "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n"
+	for tr := 0; tr < 3; tr++ {
+		tid := fmt.Sprintf("t%d", tr)
+		trips += fmt.Sprintf("%s,wk,%s,shp\n", route, tid)
+		base := 6*3600 + tr*1800
+		for i, s := range stops {
+			sec := base + i*300
+			hms := fmt.Sprintf("%02d:%02d:%02d", sec/3600, (sec/60)%60, sec%60)
+			st += fmt.Sprintf("%s,%s,%s,%s,%d\n", tid, hms, hms, s.id, i+1)
+		}
+	}
+	add("trips.txt", trips)
+	add("stop_times.txt", st)
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeRail(t *testing.T, path string, ways map[string][][2]float64) {
+	t.Helper()
+	type feat struct {
+		Type  string         `json:"type"`
+		ID    string         `json:"id"`
+		Props map[string]any `json:"properties"`
+		Geom  map[string]any `json:"geometry"`
+	}
+	var feats []feat
+	ids := make([]string, 0, len(ways))
+	for id := range ways {
+		ids = append(ids, id)
+	}
+	// deterministic file bytes
+	for i := 0; i < len(ids); i++ {
+		for j := i + 1; j < len(ids); j++ {
+			if ids[j] < ids[i] {
+				ids[i], ids[j] = ids[j], ids[i]
+			}
+		}
+	}
+	for _, id := range ids {
+		feats = append(feats, feat{Type: "Feature", ID: id,
+			Props: map[string]any{"railway": "rail"},
+			Geom:  map[string]any{"type": "LineString", "coordinates": ways[id]}})
+	}
+	raw, err := json.Marshal(map[string]any{"type": "FeatureCollection", "features": feats})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// curveH/curveV: gently wiggling lines — a perfectly straight corridor
+// simplifies to two points and the build lands under the planner's
+// 3000-byte "drawn" floor. The sine has period 0.01 deg, so it is zero
+// at every 0.005 grid point: stops sit exactly on the curve and the
+// branch joins the corridor at a shared node.
+func curveH(x0, x1, y0, amp float64) [][2]float64 {
+	var pts [][2]float64
+	for x := x0; x < x1+0.00025; x += 0.0005 {
+		pts = append(pts, [2]float64{x, y0 + amp*mathSin((x-x0)/0.01)})
+	}
+	return pts
+}
+
+func curveV(x0, y0, y1, amp float64) [][2]float64 {
+	var pts [][2]float64
+	for y := y0; y < y1+0.00025; y += 0.0005 {
+		pts = append(pts, [2]float64{x0 + amp*mathSin((y-y0)/0.01), y})
+	}
+	return pts
+}
+
+func mathSin(periods float64) float64 {
+	return math.Sin(2 * math.Pi * periods)
+}
+
+func corridorAPts() [][2]float64 { return curveH(-100.00, -99.95, 40.00, 0.002) }
+func branchBPts() [][2]float64   { return curveV(-99.97, 40.00, 40.03, 0.002) }
+func corridorCPts() [][2]float64 { return curveH(-100.50, -100.45, 40.30, 0.002) }
+
+// m2Shape: the corridor shared with m1 up to the junction, then the
+// branch north as far as endLat. Truncating endLat is the canonical
+// "feed changed upstream" edit — the service really shortens, so the
+// drawn ink (which follows the MATCHED RAIL, not the shape polyline)
+// actually moves.
+func m2Shape(endLat float64) [][2]float64 {
+	var shape [][2]float64
+	for _, p := range corridorAPts() {
+		if p[0] <= -99.97+1e-9 {
+			shape = append(shape, p)
+		}
+	}
+	for _, p := range branchBPts()[1:] {
+		if p[1] <= endLat+1e-9 {
+			shape = append(shape, p)
+		}
+	}
+	return shape
+}
+
+// writeM2 writes m2's zip with the branch running to endLat, the
+// terminal stop riding along.
+func writeM2(t *testing.T, path string, endLat float64) {
+	t.Helper()
+	writeMicroGTFS(t, path, "r2", []microStop{
+		{"s1", "Alpha", -100.00, 40.00}, {"s4", "Delta", -99.97, 40.00},
+		{"s5", "Epsilon", -99.97, endLat},
+	}, m2Shape(endLat))
+}
+
+// writeMicroWorkspace lays down the whole world: three zips, three rail
+// extracts, portolan.json. m1 carries an onestop id so the gtfs_ids
+// plumbing is exercised end to end.
+func writeMicroWorkspace(t *testing.T, dir string) {
+	t.Helper()
+	for _, sub := range []string{"gtfs", "rail", "build"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	corridorA := corridorAPts()
+	branch := branchBPts()
+	corridorC := corridorCPts()
+
+	writeMicroGTFS(t, filepath.Join(dir, "gtfs", "m1.zip"), "r1", []microStop{
+		{"s1", "Alpha", -100.00, 40.00}, {"s2", "Beta", -99.975, 40.00}, {"s3", "Gamma", -99.95, 40.00},
+	}, corridorA)
+	writeM2(t, filepath.Join(dir, "gtfs", "m2.zip"), 40.03)
+	writeMicroGTFS(t, filepath.Join(dir, "gtfs", "m3.zip"), "r3", []microStop{
+		{"s6", "Zeta", -100.50, 40.30}, {"s7", "Eta", -100.475, 40.30}, {"s8", "Theta", -100.45, 40.30},
+	}, corridorC)
+
+	writeRail(t, filepath.Join(dir, "rail", "m1.geojson"), map[string][][2]float64{"way/1": corridorA})
+	writeRail(t, filepath.Join(dir, "rail", "m2.geojson"), map[string][][2]float64{"way/1": corridorA, "way/2": branch})
+	writeRail(t, filepath.Join(dir, "rail", "m3.geojson"), map[string][][2]float64{"way/3": corridorC})
+
+	doc := NewObj()
+	doc.Set("sketches", "sketches")
+	fo := NewObj()
+	entry := func(key, name string, bbox []float64, onestop string) {
+		e := NewObj()
+		e.Set("name", name)
+		e.Set("gtfs", "gtfs/"+key+".zip")
+		e.Set("rail", "rail/"+key+".geojson")
+		e.Set("out", "build/"+key+".geojson")
+		e.Set("bbox", []any{bbox[0], bbox[1], bbox[2], bbox[3]})
+		if onestop != "" {
+			e.Set("onestop", onestop)
+		}
+		fo.Set(key, e)
+	}
+	entry("m1", "Metro One", []float64{-100.01, 39.99, -99.94, 40.01}, "f-test~m1")
+	entry("m2", "Metro Two", []float64{-100.01, 39.99, -99.96, 40.04}, "")
+	entry("m3", "Metro Three", []float64{-100.51, 40.29, -100.44, 40.31}, "")
+	doc.Set("feeds", fo)
+	if err := os.WriteFile(filepath.Join(dir, "portolan.json"), MarshalDoc(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ------------------------------------------------------------ helpers
+
+func planAndRun(t *testing.T, changed []string, global bool, bin string) (*Plan, *RunResult) {
+	t.Helper()
+	raw, err := os.ReadFile("portolan.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := registry.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := ParseDoc(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := LoadState("build/sync-state.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := BuildPlan(PlanOpts{Config: cfg, Doc: doc, State: st,
+		Changed: changed, BuildDir: "build", Global: global, Log: t.Logf})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := Run(plan, RunOpts{
+		ConfigPath: "portolan.json", StatePath: "build/sync-state.json",
+		BuildDir: "build", TilesDir: "build/tiles", ExportDir: "build/export",
+		StyleDir: "style", Jobs: 2, Portolan: bin, Log: t.Logf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan, res
+}
+
+// hashTree maps every file under root (relative path, /-separated) to
+// its content hash.
+func hashTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		h := sha256.Sum256(raw)
+		out[filepath.ToSlash(rel)] = hex.EncodeToString(h[:])
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func copyTree(t *testing.T, src, dst string) {
+	t.Helper()
+	err := filepath.WalkDir(src, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		q := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(q, 0o755)
+		}
+		in, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		out, err := os.Create(q)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			out.Close()
+			return err
+		}
+		return out.Close()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func diffTrees(t *testing.T, a, b map[string]string, what string) {
+	t.Helper()
+	for k, ha := range a {
+		hb, ok := b[k]
+		if !ok {
+			t.Errorf("%s: %s only in patch tree", what, k)
+		} else if ha != hb {
+			t.Errorf("%s: %s differs", what, k)
+		}
+	}
+	for k := range b {
+		if _, ok := a[k]; !ok {
+			t.Errorf("%s: %s only in fresh-global tree", what, k)
+		}
+	}
+}
+
+// -------------------------------------------------------------- tests
+
+// TestPatchEqualsGlobal is the oracle (docs/SYNC.md): after one feed's
+// zip changes, patch must leave tiles/export trees and a registry byte-
+// identical to a fresh global run over the same inputs — and rebuild
+// strictly fewer builds.
+func TestPatchEqualsGlobal(t *testing.T) {
+	bin := portolanBin(t)
+	ws := t.TempDir()
+	writeMicroWorkspace(t, ws)
+	t.Chdir(ws)
+
+	// run 1: nothing is drawn yet, so no groups derive — three
+	// standalone builds
+	_, r1 := planAndRun(t, nil, true, bin)
+	if len(r1.Errors) != 0 {
+		t.Fatalf("run1 errors: %v", r1.Errors)
+	}
+	if !reflect.DeepEqual(r1.Rebuilt, []string{"m1", "m2", "m3"}) {
+		t.Fatalf("run1 rebuilt = %v", r1.Rebuilt)
+	}
+	// gtfs_ids plumbing: m1's onestop id must reach its station labels
+	stations, err := os.ReadFile("build/m1.geojson.stations.geojson")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(stations, []byte("f-test~m1")) {
+		t.Error("m1 stations carry no gtfs_ids from the registry onestop")
+	}
+
+	// run 2: builds exist, m1+m2 share 2.6 km — the group derives,
+	// builds, verifies, tiles; the members clean-skip
+	p2, r2 := planAndRun(t, nil, true, bin)
+	if len(p2.GroupsCreated) != 1 {
+		t.Fatalf("run2 groups created = %v", p2.GroupsCreated)
+	}
+	group := p2.GroupsCreated[0]
+	if len(r2.Errors) != 0 {
+		t.Fatalf("run2 errors: %v", r2.Errors)
+	}
+	if !reflect.DeepEqual(r2.Rebuilt, []string{group}) {
+		t.Fatalf("run2 rebuilt = %v (members must clean-skip)", r2.Rebuilt)
+	}
+	if !r2.GroupsRewritten {
+		t.Fatal("run2 must rewrite the registry")
+	}
+	// the world index: the same helper the atlas serves — group + m3,
+	// members skipped; and it must equal what the file says
+	finalCfg, err := registry.Load("portolan.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := tiles.Index(finalCfg, func(k string) string { return filepath.Join("build/tiles", k) })
+	var feeds []string
+	for _, e := range idx {
+		feeds = append(feeds, e.Feed)
+	}
+	wantIdx := []string{group, "m3"}
+	sort.Strings(wantIdx)
+	if !reflect.DeepEqual(feeds, wantIdx) {
+		t.Fatalf("index feeds = %v, want %v", feeds, wantIdx)
+	}
+	want, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile("build/tiles/index.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(bytes.TrimSpace(got), want) {
+		t.Fatalf("static index.json diverges from the atlas helper:\n%s\n----\n%s", got, want)
+	}
+	// the pyramid carries the resolved style manifest
+	sty, err := os.ReadFile(filepath.Join("build/tiles", group, "style.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	built, err := os.ReadFile("build/" + group + ".geojson.style.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(sty, built) {
+		t.Fatal("pyramid style.json is not the build's resolved manifest")
+	}
+
+	// run 2b: a settled world reruns to zero work — the resumability
+	// guarantee (kill anywhere, rerun, nothing rebuilds twice)
+	_, r2b := planAndRun(t, nil, true, bin)
+	if len(r2b.Rebuilt) != 0 || len(r2b.Errors) != 0 {
+		t.Fatalf("settled rerun rebuilt %v (errors %v)", r2b.Rebuilt, r2b.Errors)
+	}
+
+	// the change: m2's branch truncates to 40.02 — a new feed version
+	// whose drawn ink genuinely moves
+	writeM2(t, "gtfs/m2.zip", 40.02)
+
+	// fresh copy of the post-change workspace for the oracle run
+	ws2 := t.TempDir()
+	copyTree(t, ws, ws2)
+	if err := os.Remove(filepath.Join(ws2, "build", "sync-state.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	// patch on the live workspace
+	_, rp := planAndRun(t, []string{"m2"}, false, bin)
+	if len(rp.Errors) != 0 {
+		t.Fatalf("patch errors: %v", rp.Errors)
+	}
+	patchTiles := hashTree(t, "build/tiles")
+	patchExport := hashTree(t, "build/export")
+	patchReg, err := os.ReadFile("portolan.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// fresh global on the copy
+	t.Chdir(ws2)
+	_, rg := planAndRun(t, nil, true, bin)
+	if len(rg.Errors) != 0 {
+		t.Fatalf("fresh global errors: %v", rg.Errors)
+	}
+	globalTiles := hashTree(t, "build/tiles")
+	globalExport := hashTree(t, "build/export")
+	globalReg, err := os.ReadFile("portolan.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diffTrees(t, patchTiles, globalTiles, "tiles")
+	diffTrees(t, patchExport, globalExport, "export")
+	if !bytes.Equal(patchReg, globalReg) {
+		t.Errorf("registries diverge:\n%s\n----\n%s", patchReg, globalReg)
+	}
+	if len(rp.Rebuilt) >= len(rg.Rebuilt) {
+		t.Errorf("patch rebuilt %v — must be strictly fewer than global's %v", rp.Rebuilt, rg.Rebuilt)
+	}
+	// RESULT composition: the run reports what it did
+	if !reflect.DeepEqual(rp.Changed, []string{"m2"}) {
+		t.Errorf("patch changed = %v", rp.Changed)
+	}
+	if rp.Tiles.Written == 0 {
+		t.Error("patch wrote no tiles")
+	}
+	wantExp := []string{"m1.zip", "m2.zip", "m3.zip"}
+	if !reflect.DeepEqual(rp.Exported, wantExp) {
+		t.Errorf("exported = %v, want %v", rp.Exported, wantExp)
+	}
+}
+
+// TestRunResumesIncrementally: state stamps make a rerun skip clean
+// feeds — corrupting one feed's stamp rebuilds exactly that feed.
+func TestRunResumesIncrementally(t *testing.T) {
+	bin := portolanBin(t)
+	ws := t.TempDir()
+	writeMicroWorkspace(t, ws)
+	t.Chdir(ws)
+
+	_, r1 := planAndRun(t, nil, true, bin)
+	if len(r1.Errors) != 0 {
+		t.Fatalf("run1 errors: %v", r1.Errors)
+	}
+	// simulate a run killed after m1 and m2: erase m3's stamps
+	st, err := LoadState("build/sync-state.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := st.Feeds["m3"]
+	row.Built, row.Tiled, row.Exported = "", "", ""
+	st.Feeds["m3"] = row
+	if err := st.Save("build/sync-state.json"); err != nil {
+		t.Fatal(err)
+	}
+	_, r2 := planAndRun(t, nil, true, bin)
+	rebuilt := []string{}
+	for _, k := range r2.Rebuilt {
+		if k == "m1" || k == "m2" || k == "m3" {
+			rebuilt = append(rebuilt, k)
+		}
+	}
+	if !reflect.DeepEqual(rebuilt, []string{"m3"}) {
+		t.Fatalf("rerun rebuilt %v, want just m3", r2.Rebuilt)
+	}
+}
+
+// TestRunIsolatesErrors: one feed's broken zip lands in Errors while
+// every other build completes and the index still updates.
+func TestRunIsolatesErrors(t *testing.T) {
+	bin := portolanBin(t)
+	ws := t.TempDir()
+	writeMicroWorkspace(t, ws)
+	t.Chdir(ws)
+	if err := os.WriteFile("gtfs/m3.zip", []byte("this is not a zip"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, res := planAndRun(t, nil, true, bin)
+	if len(res.Errors) != 1 || !strings.HasPrefix(res.Errors[0], "m3:") {
+		t.Fatalf("errors = %v, want one m3 failure", res.Errors)
+	}
+	for _, k := range []string{"m1", "m2"} {
+		if _, err := os.Stat(filepath.Join("build/tiles", k, "tiles.json")); err != nil {
+			t.Errorf("%s pyramid missing after m3's failure", k)
+		}
+	}
+	if _, err := os.Stat("build/tiles/index.json"); err != nil {
+		t.Error("index.json missing after a partial run")
+	}
+}
+
+// TestVerifyDropCascade: a group failing the ink gate is deleted from
+// the registry, its pyramid removed, and its members return to the
+// world index.
+func TestVerifyDropCascade(t *testing.T) {
+	bin := portolanBin(t)
+	ws := t.TempDir()
+	writeMicroWorkspace(t, ws)
+	t.Chdir(ws)
+	_, r1 := planAndRun(t, nil, true, bin)
+	if len(r1.Errors) != 0 {
+		t.Fatalf("run1 errors: %v", r1.Errors)
+	}
+	p2, r2 := planAndRun(t, nil, true, bin)
+	if len(p2.GroupsCreated) != 1 || len(r2.Errors) != 0 {
+		t.Fatalf("group not created cleanly: %v %v", p2.GroupsCreated, r2.Errors)
+	}
+	group := p2.GroupsCreated[0]
+
+	// force the gate to fail and change m2 so the group rebuilds
+	old := verifyGroupFn
+	verifyGroupFn = func(cfg registry.Config, buildDir, key string) (verifyResult, error) {
+		return verifyResult{Worst: 0.5, Bad: []string{"m1 50%"}}, nil
+	}
+	defer func() { verifyGroupFn = old }()
+	writeM2(t, "gtfs/m2.zip", 40.02)
+	_, rp := planAndRun(t, []string{"m2"}, false, bin)
+
+	hasDropError := false
+	for _, e := range rp.Errors {
+		if strings.Contains(e, "verify failed") {
+			hasDropError = true
+		}
+	}
+	if !hasDropError {
+		t.Fatalf("errors = %v, want a verify-failed entry", rp.Errors)
+	}
+	if !rp.GroupsRewritten {
+		t.Error("drop must report a registry rewrite")
+	}
+	cfg, err := registry.Load("portolan.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Feeds[group]; ok {
+		t.Error("dropped group still in the registry")
+	}
+	if _, err := os.Stat(filepath.Join("build/tiles", group)); !os.IsNotExist(err) {
+		t.Error("dropped group's pyramid still on disk")
+	}
+	idxRaw, err := os.ReadFile("build/tiles/index.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var idx []tiles.IndexEntry
+	if err := json.Unmarshal(idxRaw, &idx); err != nil {
+		t.Fatal(err)
+	}
+	var feeds []string
+	for _, e := range idx {
+		feeds = append(feeds, e.Feed)
+	}
+	if !reflect.DeepEqual(feeds, []string{"m1", "m2", "m3"}) {
+		t.Fatalf("index after drop = %v, want the members restored", feeds)
+	}
+}
+
+// TestVerifyGroupGate: the faithful groupverify.py port, on crafted
+// geometry — a member whose ink the group kept passes, one drawn 300 m
+// away fails.
+func TestVerifyGroupGate(t *testing.T) {
+	ws := t.TempDir()
+	t.Chdir(ws)
+	if err := os.MkdirAll("build", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(y float64) []byte {
+		fc := map[string]any{"type": "FeatureCollection", "features": []any{
+			map[string]any{"type": "Feature",
+				"properties": map[string]any{"band_min": 15, "band_max": 16, "kind": "steady"},
+				"geometry": map[string]any{"type": "LineString",
+					"coordinates": [][2]float64{{-100.00, y}, {-99.98, y}}}},
+		}}
+		raw, _ := json.Marshal(fc)
+		return raw
+	}
+	os.WriteFile("build/g.geojson", line(40.0), 0o644)
+	os.WriteFile("build/near.geojson", line(40.0001), 0o644) // ~11 m off
+	os.WriteFile("build/far.geojson", line(40.003), 0o644)   // ~330 m off
+	cfg := registry.Config{Feeds: map[string]registry.FeedCfg{
+		"g":    {Out: "build/g.geojson", Members: []string{"near", "far"}},
+		"near": {Out: "build/near.geojson"},
+		"far":  {Out: "build/far.geojson"},
+	}}
+	v, err := verifyGroup(cfg, "build", "g")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v.Bad) != 1 || !strings.HasPrefix(v.Bad[0], "far ") {
+		t.Fatalf("bad = %v, want far held out", v.Bad)
+	}
+	if v.Worst > 0.5 {
+		t.Fatalf("worst = %.2f", v.Worst)
+	}
+}

--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -1,0 +1,95 @@
+// Package sync reconciles the feed fleet against upstream: notice which
+// GTFS feeds changed, download them, and (in later phases) rebuild exactly
+// the builds whose inputs changed. docs/SYNC.md is the contract.
+package sync
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// stateVersion guards the manifest format. A manifest this binary does
+// not speak is an error, not a shrug — silently reinterpreting it would
+// re-download (or worse, skip) the whole fleet.
+const stateVersion = 1
+
+// FeedState is one feed's bookkeeping row in sync-state.json. The content
+// hash is the identity that matters: transitland occasionally republishes
+// identical bytes under a new sha, and Built/Tiled/Exported compare
+// against Content to say whether a stage is clean.
+type FeedState struct {
+	Onestop  string `json:"onestop,omitempty"`
+	SHA1     string `json:"sha1,omitempty"`     // transitland feed_version sha at last download
+	Content  string `json:"content,omitempty"`  // sha256 over sorted *.txt members of the zip
+	Built    string `json:"built,omitempty"`    // content hash at last successful build
+	Tiled    string `json:"tiled,omitempty"`    // content hash at last successful tiling
+	Exported string `json:"exported,omitempty"` // content hash at last successful export
+}
+
+// State is the sync manifest. It is written after each feed completes, so
+// an interrupted run resumes where it stopped.
+type State struct {
+	Version   int                  `json:"version"`
+	LastCheck string               `json:"last_check,omitempty"`
+	Feeds     map[string]FeedState `json:"feeds"`
+}
+
+// LoadState reads the manifest. A missing file is an empty state — the
+// first run of a fresh checkout, not an error.
+func LoadState(path string) (*State, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return &State{Version: stateVersion, Feeds: map[string]FeedState{}}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var st State
+	if err := json.Unmarshal(raw, &st); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if st.Version != stateVersion {
+		return nil, fmt.Errorf("%s: manifest version %d, this binary speaks %d", path, st.Version, stateVersion)
+	}
+	if st.Feeds == nil {
+		st.Feeds = map[string]FeedState{}
+	}
+	return &st, nil
+}
+
+// Save writes the manifest atomically: temp file in the same directory,
+// then rename, so a crash mid-write leaves the previous manifest intact
+// rather than a truncated one.
+func (st *State) Save(path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+	if _, err := tmp.Write(raw); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	return nil
+}

--- a/internal/sync/state_test.go
+++ b/internal/sync/state_test.go
@@ -1,0 +1,77 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStateMissingFileIsEmpty(t *testing.T) {
+	st, err := LoadState(filepath.Join(t.TempDir(), "nope", "sync-state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Version != stateVersion || len(st.Feeds) != 0 {
+		t.Errorf("empty state = %+v", st)
+	}
+}
+
+func TestStateRoundtrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deep", "sync-state.json")
+	st := &State{Version: stateVersion, LastCheck: "2026-08-20T04:00:00Z", Feeds: map[string]FeedState{
+		"mta": {Onestop: "f-dr5r-nyct", SHA1: "aaa", Content: "bbb", Built: "bbb"},
+	}}
+	if err := st.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadState(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.LastCheck != st.LastCheck || got.Feeds["mta"] != st.Feeds["mta"] {
+		t.Errorf("roundtrip = %+v", got)
+	}
+
+	// saving over an existing manifest must leave no temp droppings —
+	// the atomic rename either happened or it did not
+	st.Feeds["mta"] = FeedState{SHA1: "ccc"}
+	if err := st.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "sync-state.json" {
+		names := []string{}
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("leftover files after save: %v", names)
+	}
+	got, err = LoadState(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Feeds["mta"].SHA1 != "ccc" {
+		t.Errorf("second save not visible: %+v", got.Feeds["mta"])
+	}
+}
+
+func TestStateUnknownVersionRejected(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sync-state.json")
+	os.WriteFile(path, []byte(`{"version": 99, "feeds": {}}`), 0o644)
+	_, err := LoadState(path)
+	if err == nil || !strings.Contains(err.Error(), "version 99") {
+		t.Errorf("want version rejection, got %v", err)
+	}
+}
+
+func TestStateGarbageRejected(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sync-state.json")
+	os.WriteFile(path, []byte(`{"version": 1, "fee`), 0o644)
+	if _, err := LoadState(path); err == nil {
+		t.Error("truncated manifest loaded without error")
+	}
+}

--- a/internal/sync/transitland.go
+++ b/internal/sync/transitland.go
@@ -1,0 +1,192 @@
+package sync
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// DefaultBaseURL is transitland's v2 REST root — the same API
+// tools/feed.sh talks to for onboarding.
+const DefaultBaseURL = "https://transit.land/api/v2/rest"
+
+// Client talks to transitland. Requests go out sequentially and a 429 is
+// honored once (Retry-After, then one retry) — sync polls a fleet, and a
+// fleet-sized burst is exactly what the rate limit is for.
+type Client struct {
+	BaseURL string       // injectable for tests; "" means DefaultBaseURL
+	APIKey  string       // appended as ?apikey=; "" sends none
+	HTTP    *http.Client // nil means http.DefaultClient
+	// Sleep is the 429 backoff, injectable so tests don't wait.
+	Sleep func(time.Duration)
+}
+
+// NewClient returns a client for the public API with the given key.
+func NewClient(apiKey string) *Client { return &Client{APIKey: apiKey} }
+
+// FeedInfo is what check needs from a feed record: the current version's
+// identity, and the operator's own URL as a download fallback.
+type FeedInfo struct {
+	SHA1          string // feed_state.feed_version.sha1
+	StaticCurrent string // urls.static_current
+}
+
+func (c *Client) base() string {
+	if c.BaseURL != "" {
+		return c.BaseURL
+	}
+	return DefaultBaseURL
+}
+
+func (c *Client) withKey(u string) string {
+	if c.APIKey == "" {
+		return u
+	}
+	sep := "?"
+	if parsed, err := url.Parse(u); err == nil && parsed.RawQuery != "" {
+		sep = "&"
+	}
+	return u + sep + "apikey=" + url.QueryEscape(c.APIKey)
+}
+
+// get performs one GET, retrying exactly once on 429 after Retry-After
+// (default 1s, capped at 60s). More persistence than that is impoliteness
+// with extra steps — the run carries on and the feed lands in errors.
+func (c *Client) get(u string) (*http.Response, error) {
+	httpc := c.HTTP
+	if httpc == nil {
+		httpc = http.DefaultClient
+	}
+	resp, err := httpc.Get(u)
+	if err != nil || resp.StatusCode != http.StatusTooManyRequests {
+		return resp, err
+	}
+	wait := time.Second
+	if s := resp.Header.Get("Retry-After"); s != "" {
+		if secs, err := strconv.Atoi(s); err == nil && secs >= 0 {
+			wait = time.Duration(secs) * time.Second
+		}
+	}
+	if wait > time.Minute {
+		wait = time.Minute
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	sleep := c.Sleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	sleep(wait)
+	return httpc.Get(u)
+}
+
+// tlFeed mirrors the slice of a transitland feed record check reads.
+type tlFeed struct {
+	FeedState struct {
+		FeedVersion struct {
+			SHA1 string `json:"sha1"`
+		} `json:"feed_version"`
+	} `json:"feed_state"`
+	URLs struct {
+		StaticCurrent string `json:"static_current"`
+	} `json:"urls"`
+}
+
+// Feed fetches feeds/{onestop} and returns the current version's sha and
+// the static_current fallback URL.
+func (c *Client) Feed(onestop string) (FeedInfo, error) {
+	u := c.withKey(c.base() + "/feeds/" + url.PathEscape(onestop))
+	resp, err := c.get(u)
+	if err != nil {
+		return FeedInfo{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return FeedInfo{}, fmt.Errorf("feeds/%s: HTTP %s", onestop, resp.Status)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return FeedInfo{}, err
+	}
+	// the list endpoint wraps records in {"feeds":[…]}; a key lookup may
+	// return the record bare — accept both rather than betting on one
+	var wrapped struct {
+		Feeds []tlFeed `json:"feeds"`
+	}
+	var rec tlFeed
+	if err := json.Unmarshal(raw, &wrapped); err == nil && len(wrapped.Feeds) > 0 {
+		rec = wrapped.Feeds[0]
+	} else if err := json.Unmarshal(raw, &rec); err != nil {
+		return FeedInfo{}, fmt.Errorf("feeds/%s: %w", onestop, err)
+	}
+	return FeedInfo{SHA1: rec.FeedState.FeedVersion.SHA1, StaticCurrent: rec.URLs.StaticCurrent}, nil
+}
+
+// Download fetches the feed's current zip to path, atomically (temp file
+// beside it, verify it is a zip, rename). download_latest_feed_version
+// serves the zip when the licence allows redistribution; otherwise the
+// operator's static_current URL is tried — the same two-step
+// tools/feed.sh uses.
+func (c *Client) Download(onestop, staticCurrent, path string) error {
+	primary := c.withKey(c.base() + "/feeds/" + url.PathEscape(onestop) + "/download_latest_feed_version")
+	err := c.fetch(primary, path)
+	if err == nil {
+		return nil
+	}
+	if staticCurrent == "" {
+		return fmt.Errorf("download_latest_feed_version: %w (and no static_current fallback)", err)
+	}
+	if fbErr := c.fetch(staticCurrent, path); fbErr != nil {
+		return fmt.Errorf("download_latest_feed_version: %v; static_current: %w", err, fbErr)
+	}
+	return nil
+}
+
+func (c *Client) fetch(u, path string) error {
+	resp, err := c.get(u)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		return fmt.Errorf("HTTP %s", resp.Status)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	// an HTML error page saved as feed.zip poisons every later stage;
+	// refuse anything the zip reader cannot open
+	if zr, err := zip.OpenReader(tmp.Name()); err != nil {
+		os.Remove(tmp.Name())
+		return fmt.Errorf("not a zip: %v", err)
+	} else {
+		zr.Close()
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	return nil
+}

--- a/internal/sync/verify.go
+++ b/internal/sync/verify.go
@@ -1,0 +1,163 @@
+package sync
+
+// Did the group keep everything its members drew? The Go port of
+// tools/groupverify.py, faithful to its constants and sampling: every
+// member's own band-15 non-transition centerlines are sampled at 25 m,
+// and each sample must land within 30 m of the group's ink. Tested on
+// GEOMETRY, not labels — a group re-trunks its lines, so a label check
+// would read a rename as a loss. What must not change is the INK.
+//
+// This is the gate that keeps automatic grouping safe: a group REPLACES
+// its members in the world index, so a group that quietly drew less
+// than they did would take the difference off the map with nobody
+// watching. A failing group is deleted from the registry, which puts
+// its members straight back on the map.
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+
+	"github.com/alexwohlbruck/portolan/internal/registry"
+)
+
+const (
+	verifyStepM = 25.0 // sample the member's centrelines this finely
+	verifyTolM  = 30.0 // ...and call one covered if the group drew within this
+	verifyMin   = 0.90 // each member must retain this fraction of its ink
+)
+
+// verifyResult reports one group's gate outcome.
+type verifyResult struct {
+	Worst float64  // lowest member retention
+	Bad   []string // "member 87%" for members under the floor
+}
+
+func (v verifyResult) ok() bool { return len(v.Bad) == 0 }
+
+// verifySamples reads a build and samples its band-15 non-transition
+// lines every 25 m, exactly as groupverify.py does: n interpolated
+// points per segment, endpoints arriving as the next segment's start.
+func verifySamples(path string) ([][2]float64, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var fc struct {
+		Features []struct {
+			Properties struct {
+				BandMin *float64 `json:"band_min"`
+				Kind    string   `json:"kind"`
+			} `json:"properties"`
+			Geometry struct {
+				Type        string          `json:"type"`
+				Coordinates json.RawMessage `json:"coordinates"`
+			} `json:"geometry"`
+		} `json:"features"`
+	}
+	if err := json.Unmarshal(raw, &fc); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	var out [][2]float64
+	sample := func(pts [][2]float64) {
+		for i := 0; i+1 < len(pts); i++ {
+			a, b := pts[i], pts[i+1]
+			mx := 111320 * math.Cos(a[1]*math.Pi/180)
+			dx, dy := (b[0]-a[0])*mx, (b[1]-a[1])*110540
+			n := int(math.Hypot(dx, dy) / verifyStepM)
+			if n < 1 {
+				n = 1
+			}
+			for j := 0; j < n; j++ {
+				out = append(out, [2]float64{
+					a[0] + (b[0]-a[0])*float64(j)/float64(n),
+					a[1] + (b[1]-a[1])*float64(j)/float64(n)})
+			}
+		}
+	}
+	for _, f := range fc.Features {
+		if f.Properties.BandMin == nil || *f.Properties.BandMin != 15 ||
+			f.Properties.Kind == "transition" {
+			continue
+		}
+		switch f.Geometry.Type {
+		case "LineString":
+			var pts [][2]float64
+			if json.Unmarshal(f.Geometry.Coordinates, &pts) == nil {
+				sample(pts)
+			}
+		case "MultiLineString":
+			var parts [][][2]float64
+			if json.Unmarshal(f.Geometry.Coordinates, &parts) == nil {
+				for _, pts := range parts {
+					sample(pts)
+				}
+			}
+		}
+	}
+	return out, nil
+}
+
+// verifyGroup runs the gate for one group build: grid the group's own
+// samples at the tolerance cell size, then ask what fraction of each
+// member's samples lands within 30 m. Members without a build or with
+// no band-15 ink are skipped, as the Python does.
+func verifyGroup(cfg registry.Config, buildDir, key string) (verifyResult, error) {
+	res := verifyResult{Worst: 1.0}
+	fc := cfg.Feeds[key]
+	groupSamples, err := verifySamples(outPath(fc, buildDir, key))
+	if err != nil {
+		return res, err
+	}
+	cx, cy := verifyTolM/111320.0, verifyTolM/110540.0
+	type cell [2]int
+	grid := map[cell][][2]float64{}
+	for _, p := range groupSamples {
+		c := cell{int(p[0] / cx), int(p[1] / cy)}
+		grid[c] = append(grid[c], p)
+	}
+	near := func(x, y float64) bool {
+		gx, gy := int(x/cx), int(y/cy)
+		for i := -1; i <= 1; i++ {
+			for j := -1; j <= 1; j++ {
+				for _, p := range grid[cell{gx + i, gy + j}] {
+					ddx := (p[0] - x) * 111320 * math.Cos(y*math.Pi/180)
+					ddy := (p[1] - y) * 110540
+					if math.Hypot(ddx, ddy) <= verifyTolM {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+	for _, m := range fc.Members {
+		mc, ok := cfg.Feeds[m]
+		if !ok {
+			continue
+		}
+		own := outPath(mc, buildDir, m)
+		if _, err := os.Stat(own); err != nil {
+			continue
+		}
+		ss, err := verifySamples(own)
+		if err != nil || len(ss) == 0 {
+			continue
+		}
+		hit := 0
+		for _, p := range ss {
+			if near(p[0], p[1]) {
+				hit++
+			}
+		}
+		r := float64(hit) / float64(len(ss))
+		if r < verifyMin {
+			res.Bad = append(res.Bad, fmt.Sprintf("%s %.0f%%", m, r*100))
+		}
+		if r < res.Worst {
+			res.Worst = r
+		}
+	}
+	return res, nil
+}

--- a/internal/tiles/index.go
+++ b/internal/tiles/index.go
@@ -1,0 +1,63 @@
+package tiles
+
+// The world index: every feed with a cut pyramid, with its bounds — the
+// global view draws exactly this list and nothing else. Composed HERE,
+// once, because two consumers read it: the atlas serves it live at
+// /api/tiles/index.json, and sync writes it as a static --tiles/
+// index.json after a run. One composer, so the two cannot drift.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/alexwohlbruck/portolan/internal/registry"
+)
+
+// IndexEntry is one world-index row. The schema is a contract: barrelman
+// consumes it, and it carries no URL templates — the consumer knows where
+// the pyramids live relative to the index.
+type IndexEntry struct {
+	Feed    string    `json:"feed"`
+	Name    string    `json:"name"`
+	Bounds  []float64 `json:"bounds,omitempty"`
+	MaxZoom int       `json:"maxzoom"`
+}
+
+// Index composes the world index from the registry: every feed whose
+// pyramid (dirFor(key)/tiles.json) exists, except members of groups — a
+// feed that rides inside a group is drawn BY the group, and listing both
+// would double-draw its railroad. Sorted by feed key.
+func Index(cfg registry.Config, dirFor func(feed string) string) []IndexEntry {
+	grouped := map[string]bool{}
+	for _, fc := range cfg.Feeds {
+		for _, m := range fc.Members {
+			grouped[m] = true
+		}
+	}
+	keys := make([]string, 0, len(cfg.Feeds))
+	for k := range cfg.Feeds {
+		if !grouped[k] {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	out := []IndexEntry{}
+	for _, k := range keys {
+		raw, err := os.ReadFile(filepath.Join(dirFor(k), "tiles.json"))
+		if err != nil {
+			continue
+		}
+		var tj struct {
+			Bounds  []float64 `json:"bounds"`
+			MaxZoom int       `json:"maxzoom"`
+		}
+		if json.Unmarshal(raw, &tj) != nil {
+			continue
+		}
+		out = append(out, IndexEntry{Feed: k, Name: cfg.Feeds[k].Name,
+			Bounds: tj.Bounds, MaxZoom: tj.MaxZoom})
+	}
+	return out
+}

--- a/internal/tiles/tiles.go
+++ b/internal/tiles/tiles.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // Opts configures one tiling run. Build is the ribbon GeoJSON `chart`
@@ -278,6 +279,9 @@ func Build(o Opts) (Stats, error) {
 		return st, err
 	}
 
+	if err := writeRouteIndex(o, points); err != nil {
+		return st, err
+	}
 	return st, writeTileJSON(o, minx, miny, maxx, maxy)
 }
 
@@ -741,4 +745,106 @@ func writeTileJSON(o Opts, minx, miny, maxx, maxy float64) error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(o.Out, "tiles.json"), raw, 0o644)
+}
+
+// ── the pyramid's bullet vocabulary ────────────────────────────────────
+
+// RouteStyle is how one route's bullet is drawn: the glyphs on it, its
+// colour, and the outline curation puts it in. Everything a consumer
+// needs to draw the same bullet the map draws, without the map.
+type RouteStyle struct {
+	Label string `json:"label"`
+	Color string `json:"color,omitempty"`
+	// Shape is portolan's curated outline ("square", "notch", …). Empty
+	// is the default circle, exactly as the tiles carry it — an absent
+	// shape is not "no shape".
+	Shape string `json:"shape,omitempty"`
+	Mode  string `json:"mode,omitempty"`
+}
+
+// writeRouteIndex emits <out>/routes.json: every route the pyramid draws,
+// keyed by the id its tiles use, with the bullet style already resolved.
+//
+// The map resolves curation (a route's own `shape:`, then its agency's,
+// then the default) while it builds, and bakes the answer into each
+// station's aligned arrays. A panel beside the map has no way to redo
+// that: it holds a route id from a routing engine and knows nothing about
+// portolan's style documents, so a Mexico City numeral came out a circle
+// there and a notched square on the map beside it. This publishes the
+// resolved answer next to the tiles it belongs to.
+//
+// Ids are the TILE's ids, prefixed as a group build prefixes them
+// ("f3:2"), because that is what identifies a route in this pyramid. A
+// consumer holding a feed's own id matches on the `:id` suffix, the same
+// way the isolation filter does.
+func writeRouteIndex(o Opts, points []point) error {
+	styles := map[string]RouteStyle{}
+	add := func(id, label, color, shape, mode string) {
+		if id == "" {
+			return
+		}
+		cur, seen := styles[id]
+		// first writer wins, but never let a blank overwrite a value:
+		// markers and stations carry the same vocabulary, and a station
+		// with one route missing a colour must not erase it
+		if !seen {
+			styles[id] = RouteStyle{Label: label, Color: color, Shape: shape, Mode: mode}
+			return
+		}
+		if cur.Label == "" {
+			cur.Label = label
+		}
+		if cur.Color == "" {
+			cur.Color = color
+		}
+		if cur.Shape == "" {
+			cur.Shape = shape
+		}
+		if cur.Mode == "" {
+			cur.Mode = mode
+		}
+		styles[id] = cur
+	}
+	at := func(xs []string, i int) string {
+		if i < len(xs) {
+			return xs[i]
+		}
+		return ""
+	}
+	for _, p := range points {
+		switch str(p.props["ftype"]) {
+		case "station", "marker":
+			ids := splitCSV(str(p.props["routes"]))
+			labels := splitCSV(str(p.props["labels"]))
+			colors := splitCSV(str(p.props["route_colors"]))
+			shapes := splitCSV(str(p.props["shapes"]))
+			modes := splitCSV(str(p.props["modes"]))
+			for i, id := range ids {
+				add(id, at(labels, i), at(colors, i), at(shapes, i), at(modes, i))
+			}
+		case "cat":
+			// a caterpillar names one route on its own — the only place a
+			// route with no drawn station still states its bullet
+			add(str(p.props["route"]), str(p.props["label"]),
+				str(p.props["hex"]), str(p.props["shape"]), str(p.props["mode"]))
+		}
+	}
+	if len(styles) == 0 {
+		return nil // nothing to say; no file rather than an empty one
+	}
+	raw, err := json.MarshalIndent(styles, "", " ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(o.Out, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(o.Out, "routes.json"), raw, 0o644)
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, ",")
 }

--- a/portolan.json
+++ b/portolan.json
@@ -14,7 +14,8 @@
         40.92
       ],
       "network": "sketches/network-5.json",
-      "out": "build/mta-subway.geojson"
+      "out": "build/mta-subway.geojson",
+      "onestop": "f-dr5r-nyctsubway"
     },
     "mta-metro-north": {
       "name": "Metro-North Railroad",
@@ -29,7 +30,8 @@
         40.92
       ],
       "out": "build/mta-metro-north.geojson",
-      "network": "sketches/network-mta-metro-north.json"
+      "network": "sketches/network-mta-metro-north.json",
+      "onestop": "f-dr7-mtanyc~metro~north"
     },
     "mta-lirr": {
       "name": "Long Island Rail Road",
@@ -44,7 +46,8 @@
         40.92
       ],
       "out": "build/mta-lirr.geojson",
-      "network": "sketches/network-mta-lirr.json"
+      "network": "sketches/network-mta-lirr.json",
+      "onestop": "f-dr5-mtanyclirr"
     },
     "nyc-ferry": {
       "name": "NYC Ferry",
@@ -89,7 +92,8 @@
         40.92
       ],
       "out": "build/jfk-airtrain.geojson",
-      "network": "sketches/network-jfk-airtrain.json"
+      "network": "sketches/network-jfk-airtrain.json",
+      "onestop": "f-dr5x2-jfkairtrain"
     },
     "mta-nyct-bus": {
       "name": "MTA NYCT Bus",
@@ -104,7 +108,8 @@
         40.92
       ],
       "out": "build/mta-nyct-bus.geojson",
-      "network": "sketches/network-mta-nyct-bus.json"
+      "network": "sketches/network-mta-nyct-bus.json",
+      "onestop": "f-dr5r-mtanyctbusbrooklyn"
     },
     "mta-bus": {
       "name": "MTA Bus Company",
@@ -119,7 +124,8 @@
         40.92
       ],
       "out": "build/mta-bus.geojson",
-      "network": "sketches/network-mta-bus.json"
+      "network": "sketches/network-mta-bus.json",
+      "onestop": "f-dr5r-mtabc"
     },
     "chicago-cta": {
       "name": "Chicago CTA",
@@ -134,7 +140,8 @@
         42.08
       ],
       "network": "sketches/network-29.json",
-      "out": "build/chicago-cta.geojson"
+      "out": "build/chicago-cta.geojson",
+      "onestop": "f-dp3-cta"
     },
     "metra": {
       "name": "Metra",
@@ -149,7 +156,8 @@
         42.08
       ],
       "out": "build/metra.geojson",
-      "network": "sketches/network-metra.json"
+      "network": "sketches/network-metra.json",
+      "onestop": "f-dp3-metra"
     },
     "amtrak": {
       "name": "Amtrak",
@@ -164,7 +172,8 @@
         -66,
         50.5
       ],
-      "chart_args": "--set match_gap_cost=150"
+      "chart_args": "--set match_gap_cost=150",
+      "onestop": "f-9-amtrak~amtrakcalifornia~amtrakcharteredvehicle"
     },
     "viarail": {
       "name": "VIA Rail",
@@ -177,7 +186,8 @@
         -62.5,
         59.5
       ],
-      "chart_args": "--set match_gap_cost=150"
+      "chart_args": "--set match_gap_cost=150",
+      "onestop": "f-f-viarail~traindecharlevoix"
     },
     "barcelona-tmb": {
       "name": "Barcelona TMB",
@@ -191,7 +201,8 @@
         41.51
       ],
       "out": "build/barcelona-tmb.geojson",
-      "network": "sketches/network-barcelona-tmb.json"
+      "network": "sketches/network-barcelona-tmb.json",
+      "onestop": "f-sp3e-tmb"
     },
     "barcelona-fgc": {
       "name": "FGC",
@@ -205,10 +216,11 @@
         41.51
       ],
       "out": "build/barcelona-fgc.geojson",
-      "network": "sketches/network-barcelona-fgc.json"
+      "network": "sketches/network-barcelona-fgc.json",
+      "onestop": "f-fgc~cat"
     },
     "barcelona-tbs": {
-      "name": "Tram Bes\u00f2s",
+      "name": "Tram Besòs",
       "gtfs": "data/gtfs/barcelona-tbs.zip",
       "rail": "build/barcelona-rail.geojson",
       "stops": "build/barcelona-stops.geojson",
@@ -219,7 +231,8 @@
         41.51
       ],
       "out": "build/barcelona-tbs.geojson",
-      "network": "sketches/network-barcelona-tbs.json"
+      "network": "sketches/network-barcelona-tbs.json",
+      "onestop": "f-tram~tbs"
     },
     "barcelona-tbx": {
       "name": "Tram Baix",
@@ -233,7 +246,8 @@
         41.51
       ],
       "out": "build/barcelona-tbx.geojson",
-      "network": "sketches/network-barcelona-tbx.json"
+      "network": "sketches/network-barcelona-tbx.json",
+      "onestop": "f-tram~tbx"
     },
     "la-metro-rail": {
       "name": "LA Metro Rail",
@@ -248,7 +262,8 @@
         34.2
       ],
       "out": "build/la-metro-rail.geojson",
-      "network": "sketches/network-la-metro-rail.json"
+      "network": "sketches/network-la-metro-rail.json",
+      "onestop": "f-9q5-metro~losangeles~rail"
     },
     "la-metro-bus": {
       "name": "LA Metro Bus",
@@ -263,7 +278,8 @@
         34.2
       ],
       "out": "build/la-metro-bus.geojson",
-      "network": "sketches/network-la-metro-bus.json"
+      "network": "sketches/network-la-metro-bus.json",
+      "onestop": "f-9q5-metro~losangeles"
     },
     "tokyo-metro": {
       "name": "Tokyo Metro",
@@ -305,7 +321,8 @@
         39.16
       ],
       "network": "sketches/network-dc.json",
-      "out": "build/wmata.geojson"
+      "out": "build/wmata.geojson",
+      "onestop": "f-dqc-wmata~rail"
     },
     "dc-streetcar": {
       "name": "DC Streetcar",
@@ -334,7 +351,8 @@
         -84.2,
         33.96
       ],
-      "streets": "build/atlanta-streets.geojson"
+      "streets": "build/atlanta-streets.geojson",
+      "onestop": "f-dnh-marta"
     },
     "charlotte": {
       "name": "Charlotte",
@@ -349,7 +367,8 @@
         -80.68,
         35.35
       ],
-      "streets": "build/charlotte-streets.geojson"
+      "streets": "build/charlotte-streets.geojson",
+      "onestop": "f-dnq-charlotteareatransitsystem"
     },
     "london": {
       "name": "London",
@@ -378,7 +397,8 @@
         2.55,
         48.98
       ],
-      "streets": "build/paris-streets.geojson"
+      "streets": "build/paris-streets.geojson",
+      "onestop": "f-u09-paris~metro~bus~tram"
     },
     "berlin": {
       "name": "Berlin",
@@ -407,7 +427,8 @@
         19.23,
         -98.93,
         19.72
-      ]
+      ],
+      "onestop": "f-9g3-semovi"
     },
     "amsterdam": {
       "name": "Amsterdam",
@@ -435,7 +456,8 @@
         42.17,
         -70.92,
         42.48
-      ]
+      ],
+      "onestop": "f-drt-mbta"
     },
     "toronto": {
       "name": "Toronto",
@@ -449,7 +471,8 @@
         43.56,
         -79.1,
         43.88
-      ]
+      ],
+      "onestop": "f-dpz8-ttc"
     },
     "vienna": {
       "name": "Vienna",
@@ -463,7 +486,8 @@
         48.09,
         16.55,
         48.33
-      ]
+      ],
+      "onestop": "f-u2ed-wienerlinien~wlb"
     },
     "santiago": {
       "name": "Santiago",
@@ -477,7 +501,8 @@
         -33.65,
         -70.49,
         -33.33
-      ]
+      ],
+      "onestop": "f-66jc-transantiago~metrodesantiago"
     },
     "septa-rail": {
       "name": "SEPTA Regional Rail",
@@ -491,7 +516,8 @@
         -74.704,
         40.356
       ],
-      "stops": "build/septa-rail-stops.geojson"
+      "stops": "build/septa-rail-stops.geojson",
+      "onestop": "f-dr4-septa~rail"
     },
     "septa": {
       "name": "SEPTA",
@@ -505,7 +531,8 @@
         -74.704,
         40.384
       ],
-      "stops": "build/septa-stops.geojson"
+      "stops": "build/septa-stops.geojson",
+      "onestop": "f-dr4-septa~bus"
     },
     "patco": {
       "name": "PATCO",
@@ -519,7 +546,8 @@
         -74.951,
         40.005
       ],
-      "stops": "build/patco-stops.geojson"
+      "stops": "build/patco-stops.geojson",
+      "onestop": "f-dr4e-patco"
     },
     "path": {
       "name": "PATH",
@@ -533,7 +561,8 @@
         -73.939,
         40.799
       ],
-      "stops": "build/path-stops.geojson"
+      "stops": "build/path-stops.geojson",
+      "onestop": "f-dr5r-path~nj~us"
     },
     "nj-transit-rail": {
       "name": "NJ Transit Rail",
@@ -547,7 +576,8 @@
         -73.938,
         41.522
       ],
-      "stops": "build/nj-transit-rail-stops.geojson"
+      "stops": "build/nj-transit-rail-stops.geojson",
+      "onestop": "f-dr5-nj~transit~rail"
     },
     "marc": {
       "name": "MARC",
@@ -561,7 +591,8 @@
         -76.024,
         39.608
       ],
-      "stops": "build/marc-stops.geojson"
+      "stops": "build/marc-stops.geojson",
+      "onestop": "f-dq-mtamaryland~marc"
     },
     "baltimore-metro": {
       "name": "Baltimore Metro SubwayLink",
@@ -575,7 +606,8 @@
         -76.544,
         39.458
       ],
-      "stops": "build/baltimore-metro-stops.geojson"
+      "stops": "build/baltimore-metro-stops.geojson",
+      "onestop": "f-dq-mtamaryland~subwaylink"
     },
     "baltimore-light-rail": {
       "name": "Baltimore Light RailLink",
@@ -589,7 +621,8 @@
         -76.566,
         39.546
       ],
-      "stops": "build/baltimore-light-rail-stops.geojson"
+      "stops": "build/baltimore-light-rail-stops.geojson",
+      "onestop": "f-dq-mtamaryland~raillink"
     },
     "vre": {
       "name": "Virginia Railway Express",
@@ -603,7 +636,8 @@
         -76.955,
         38.95
       ],
-      "stops": "build/vre-stops.geojson"
+      "stops": "build/vre-stops.geojson",
+      "onestop": "f-dqc-virginiarailwayexpress"
     },
     "hartford-line": {
       "name": "CTrail Hartford Line",
@@ -617,10 +651,11 @@
         -72.543,
         42.156
       ],
-      "stops": "build/hartford-line-stops.geojson"
+      "stops": "build/hartford-line-stops.geojson",
+      "onestop": "f-cttransit~hartford~line"
     },
     "dallas": {
-      "name": "Dallas\u2013Fort Worth",
+      "name": "Dallas–Fort Worth",
       "gtfs": "data/gtfs/dallasarearapidtransit.zip,data/gtfs/dentoncountytransportationauthority.zip,data/gtfs/fortworthtransportationauthority.zip,data/gtfs/mckinney-avenue-transit-authority.zip,data/gtfs/amtrak.zip",
       "rail": "build/dallas-rail.geojson",
       "stops": "build/dallas-stops.geojson",
@@ -644,7 +679,7 @@
       ]
     },
     "washington": {
-      "name": "Washington\u2013Baltimore",
+      "name": "Washington–Baltimore",
       "gtfs": "data/gtfs/baltimore-light-rail.zip,data/gtfs/marc.zip,data/gtfs/vre.zip,data/gtfs/dc.zip,data/gtfs/amtrak.zip",
       "rail": "build/washington-rail.geojson",
       "stops": "build/washington-stops.geojson",
@@ -12945,7 +12980,7 @@
         -73.824,
         45.537
       ],
-      "onestop": "f-f256-exo~citlapresqu\u00eele"
+      "onestop": "f-f256-exo~citlapresquîle"
     },
     "exo-citlaurentides": {
       "name": "exo-citlaurentides",
@@ -13065,7 +13100,7 @@
         -72.895,
         45.691
       ],
-      "onestop": "f-f25g-exo~citvall\u00e9e~du~richelieu"
+      "onestop": "f-f25g-exo~citvallée~du~richelieu"
     },
     "exo-omitsainte-julie": {
       "name": "exo-omitsainte-julie",
@@ -13125,7 +13160,7 @@
         -71.765,
         45.532
       ],
-      "onestop": "f-f2hf-soci\u00e9t\u00e9detransportdesherbrooke"
+      "onestop": "f-f2hf-sociétédetransportdesherbrooke"
     },
     "laregiedetransportencommundelavilledesha": {
       "name": "laregiedetransportencommundelavilledesha",
@@ -22564,7 +22599,7 @@
       ]
     },
     "montreal": {
-      "name": "Montr\u00e9al",
+      "name": "Montréal",
       "gtfs": "data/gtfs/exo-reseaudetransportmetropolitain.zip,data/gtfs/reseau-express-metropolitain.zip,data/gtfs/socitdetransportdemontral.zip,data/gtfs/amtrak.zip,data/gtfs/viarail.zip",
       "rail": "build/montreal-rail.geojson",
       "stops": "build/montreal-stops.geojson",

--- a/tools/feed.sh
+++ b/tools/feed.sh
@@ -225,6 +225,26 @@ build() { # $1 = feed key
   # shapes.txt (docs/REGIONS.md) — env rather than a flag so `all` and
   # feed.sh reads them for every build
   if [ -n "${EXPORT_GTFS:-}" ]; then set -- "$@" --export-gtfs "$EXPORT_GTFS"; fi
+  # onestop: stations carry <feed-onestop>:<stop_id> so a consumer can open
+  # the stop a label names. Built from every zip in THIS build's gtfs list,
+  # keyed by basename, which is how chart matches a station back to the
+  # feed it came from — a group therefore labels each member's stops with
+  # that member's own id, not the group's.
+  local onestop
+  onestop=$(jq -r --arg g "$gtfs" '
+    def basename: sub("^.*/";"") | sub("\\.zip$";"");
+    . as $cfg
+    | [ ($g | split(",") | map(gsub("^\\s+|\\s+$";"")))[]
+        | . as $z
+        | ($z | basename) as $key
+        | ( $cfg.feeds[$key].onestop
+            // ( [ $cfg.feeds | to_entries[]
+                  | select(((.value.gtfs // "") | split(",") | map(gsub("^\\s+|\\s+$";"")) | first) == $z)
+                  | .value.onestop // empty ] | first )
+            // empty ) as $id
+        | "\($key)=\($id)" ]
+    | unique | join(",")' "$CFG")
+  [ -n "$onestop" ] && set -- "$@" --onestop "$onestop"
   # chart_args: per-feed extra chart flags (e.g. "--set match_gap_cost=150"
   # for us-intercity) — how a region's tuned dials survive a refresh
   local extra


### PR DESCRIPTION
Seventeen commits that make portolan drivable from barrelman and make what
it draws answerable per route. The `sync` half was written first; the rest
came out of watching the result on a real map.

## `portolan sync check | patch | global`

`docs/SYNC.md` is the contract, written before the code. The invariant it
exists to hold: **a patch produces byte-identical output to a global run**,
which is a test (`TestPatchEqualsGlobal`) rather than a hope. Finding the
closure of "input set changed" is the actual work — changed feeds, the
feeds that share steel with them, group membership re-derived over the
affected component, overlay windows that moved.

Shared steel is a measurement, not curation, so `tools/groups.py` is ported
to Go with byte-parity against the Python (`TestPythonParity` runs the
script and diffs).

## Per-route service hours

`acts` answers "is anything running on this track at this hour", which is
right for a map of a system and wrong for one line. The 2 and the 3 share
their track; at 3am the 2 runs and the 3 does not.

- `ridx` names each route's slot in the mask (`A=00;C=01;E=02`), two digits
  per route, so a filter can ask about one line. A renderer can slice a
  string at a computed offset but cannot count commas, and route ids are
  not fixed width — hence publishing the slot rather than re-deriving it.
- **Terminal cuts were deleting hours.** A pattern running a whole segment
  puts both tips on it, and each terminal stop was pairing with whichever
  tip came last. The L's terminals sit 68 m and 110 m inside the drawn
  centerline — platforms are not the end of the track — so a 16 km 24/7
  cover collapsed to a 68 m sliver and the Canarsie line went dark at
  night. Stops now trim their own end only. NYC reads like the MTA's own
  map afterwards: L/J/7/6/1 at 100% 24/7, G at 99%, C/B/W at 0%.

## Identity, so a drawn thing can be opened

- Stations carry `gtfs_ids` (`<feed-onestop>:<stop_id>`), and **markers
  carry the station's `osm` and `gtfs_ids` too** — a marker is that station
  one corridor at a time, and from the zoom where a complex's merged label
  yields, the only feature still drawing a name. Those clicks opened
  nothing before.
- Every feed has its onestop id, backfilled by zip-sha1 reverse lookup.

## `routes.json`

Each pyramid publishes the bullet vocabulary it drew: every route, keyed by
the id its tiles use, with `{label, color, shape, mode}` already resolved.
Curation decides a bullet's outline and the build resolves it; a consumer
that is not the map cannot redo that. Built from the symbols themselves so
it cannot drift from what was drawn.

---

Consumed by barrelman (`portolan-integration`) and parchment
(`portolan-atlas`); merge in that order. Verified by rebuilding and
retiling all 89 served pyramids — zero failures — and reading the results
back out of the builds.