### PR TITLE
match: a shape that leaves the steel may not testify — ride the honest twin's path

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -825,13 +825,17 @@ func writePaths(path string, paths []stages.Path, frame geo.Frame) error {
 					gaps++
 				}
 			}
-			if f, ok := lineFeature(map[string]any{
+			props := map[string]any{
 				"kind": "path", "route": p.Pattern.Route.ID,
 				"label": p.Pattern.Route.ShortName,
 				"color": p.Pattern.Route.Color, "shape": p.Pattern.ShapeID,
 				"trips": p.Pattern.Trips, "gaps": gaps,
 				"len_m": int(p.Line.Len()),
-			}, p.Line, 8, frame); ok {
+			}
+			if p.Guide != "" {
+				props["guide"] = p.Guide
+			}
+			if f, ok := lineFeature(props, p.Line, 8, frame); ok {
 				return f, true
 			}
 		}

--- a/internal/stages/match.go
+++ b/internal/stages/match.go
@@ -45,6 +45,15 @@ type matchParams struct {
 	GapFree    float64 // GAP exists only where no usable track is this close
 	GapSwitch  float64 // cost to enter/leave GAP
 	MaxWalk    float64 // cap on intermediate walk length
+	// Distrust: the off-network arc fraction past which a shape stops
+	// being the matcher's ground truth. Gap bridging (LESSONS #8) rests on
+	// the premise that the shape is honest and OSM is locally incomplete;
+	// a shape off the network for a THIRD of its length inverts that
+	// premise — the track exists and the shape lies (the Gold Runner's
+	// road-traced Bakersfield–Sacramento shape: 67% of its arc has no
+	// rail within reach, while its reverse twin rides the BNSF within
+	// 40 m). Honest shapes measure ≤5% even when OSM drops whole branches.
+	Distrust float64
 }
 
 // barredGap keeps the DP solvable where the gap gate closes but the graph is
@@ -78,6 +87,7 @@ func defaultMatchParams() matchParams {
 		GapFree:   dial("match_gap_free", 45),
 		GapSwitch: 40,
 		MaxWalk:   dial("match_max_walk", 350),
+		Distrust:  dial("match_shape_distrust", 0.33),
 	}
 }
 
@@ -191,13 +201,34 @@ func Match(patterns []gtfs.Pattern, ways []bundle.Track, frame geo.Frame) ([]Pat
 	g := buildTrackGraphCached(ways)
 	p := defaultMatchParams()
 
+	m := &matcher{g: g, p: p,
+		usedBy:    map[int]map[string]bool{},
+		usedColor: map[int]map[string]bool{},
+		walks:     map[[2]int]walkRes{}}
+
+	// Every shape is measured against the network before anything matches:
+	// a distrusted shape (see Distrust) may not serve as gap-bridging
+	// truth, because bridging a lying shape draws its lie — the Gold
+	// Runner's road-traced shape turned Stockton–Modesto into 15 km
+	// straight chords while three honest siblings rode the BNSF beside it.
+	off := make([]float64, len(patterns))
+	for i := range patterns {
+		off[i] = m.offNetworkFrac(patterns[i], frame)
+	}
+	trusted := func(i int) bool { return off[i] <= p.Distrust }
+
 	// canonical patterns first: heaviest service defines the shared paths
-	// that later patterns converge onto (owner's rule 1.1)
+	// that later patterns converge onto (owner's rule 1.1). Distrusted
+	// patterns go LAST regardless of service weight, so every liar finds
+	// its route's honest steel already laid down to borrow.
 	order := make([]int, len(patterns))
 	for i := range order {
 		order[i] = i
 	}
 	sort.SliceStable(order, func(a, b int) bool {
+		if ta, tb := trusted(order[a]), trusted(order[b]); ta != tb {
+			return ta
+		}
 		pa, pb := patterns[order[a]], patterns[order[b]]
 		if pa.Trips != pb.Trips {
 			return pa.Trips > pb.Trips
@@ -208,20 +239,138 @@ func Match(patterns []gtfs.Pattern, ways []bundle.Track, frame geo.Frame) ([]Pat
 		return pa.ShapeID < pb.ShapeID
 	})
 
-	m := &matcher{g: g, p: p,
-		usedBy:    map[int]map[string]bool{},
-		usedColor: map[int]map[string]bool{},
-		walks:     map[[2]int]walkRes{}}
 	var out []Path
+	var laid []Path // trusted patterns' paths — the guide pool
 	for _, oi := range order {
+		pat := patterns[oi]
 		// ferries match the seaway layer (OSM route=ferry lanes) like
 		// everything else; where the harbor has no mapped lane the gap
 		// machinery chords the crossing exactly as the old bypass did.
-		if path, ok := m.matchOne(patterns[oi], frame); ok {
-			out = append(out, path)
+		var guide []geo.Pt
+		var guideID string
+		if !trusted(oi) {
+			guide, guideID = guideFor(pat, laid, frame)
+			if dbgMatch {
+				println("DISTRUST", pat.Route.ID, pat.ShapeID,
+					"off-network", int(off[oi]*100), "% guide", guideID)
+			}
 		}
+		path, ok := m.matchOne(pat, frame, guide)
+		if !ok {
+			continue
+		}
+		path.Guide = guideID
+		if trusted(oi) {
+			laid = append(laid, path)
+		}
+		out = append(out, path)
 	}
 	return out, nil
+}
+
+// offNetworkFrac: the arc-weighted fraction of a pattern's shape VERTICES
+// with no same-layer track within Reach. Vertices, not resampled chords —
+// a decimated shape's vertices sit on the steel it means (the Gold
+// Runner's 5 km-chord shapes land within 40 m of the BNSF at every
+// vertex, and the chord/confidence machinery handles the spans between),
+// while a road-traced shape parks vertex after vertex on asphalt. Class
+// is NOT checked, only layer: a regional shape hugging subway steel in a
+// shared corridor is still an honest statement of where the train runs.
+func (m *matcher) offNetworkFrac(pat gtfs.Pattern, frame geo.Frame) float64 {
+	if len(pat.Shape) < 2 {
+		return 0
+	}
+	wantLayer := patternLayer(pat.Route.Type)
+	pts := make([]geo.Pt, len(pat.Shape))
+	for i, ll := range pat.Shape {
+		pts[i] = frame.ToXY(ll)
+	}
+	var offArc, total float64
+	for i, q := range pts {
+		w := 0.0
+		if i > 0 {
+			w += q.Dist(pts[i-1]) / 2
+		}
+		if i < len(pts)-1 {
+			w += q.Dist(pts[i+1]) / 2
+		}
+		if w == 0 {
+			continue
+		}
+		near := false
+		m.g.grid.Near(q, m.p.Reach, func(piece int) {
+			if near {
+				return
+			}
+			if wayRailClass != nil &&
+				wayLayer(wayRailClass[m.g.edges[2*piece].Way]) != wantLayer {
+				return
+			}
+			if _, d := m.g.pieces[piece].ProjectArc(q); d <= m.p.Reach {
+				near = true
+			}
+		})
+		total += w
+		if !near {
+			offArc += w
+		}
+	}
+	if total == 0 {
+		return 0
+	}
+	return offArc / total
+}
+
+// guideFor finds, for a pattern whose own shape is distrusted, the matched
+// path of an honest sibling to ride instead: same route, and both of the
+// pattern's terminals on the sibling's steel (the reverse twin is the
+// usual donor — the Gold Runner's Sacramento-bound shape is road junk, its
+// Bakersfield-bound twin is faithful). Terminals are the only stop
+// positions a Pattern carries, so a same-terminal different-via sibling
+// could in principle mislead — but the pattern's own shape is unusable
+// garbage, and the sibling's steel is the best statement of the route
+// anyone has. No donor found means no guide: the pattern matches on its
+// own shape exactly as before, because a lying shape with no honest
+// sibling is still the only geometry that exists (LESSONS #8 feeds with
+// whole branches missing from OSM must keep bridging).
+func guideFor(pat gtfs.Pattern, laid []Path, frame geo.Frame) ([]geo.Pt, string) {
+	if pat.TermAID == "" || pat.TermBID == "" {
+		return nil, ""
+	}
+	// a terminal sits beside the steel, not on it (platforms, station
+	// throats); a wrong-branch sibling misses by kilometres
+	const termTol = 300.0
+	a, b := frame.ToXY(pat.TermA), frame.ToXY(pat.TermB)
+	best := -1
+	bestMiss := math.Inf(1)
+	for i, p := range laid {
+		if p.Pattern.Route.ID != pat.Route.ID {
+			continue
+		}
+		_, da := p.Line.ProjectArc(a)
+		_, db := p.Line.ProjectArc(b)
+		if da > termTol || db > termTol {
+			continue
+		}
+		if da+db < bestMiss {
+			best, bestMiss = i, da+db
+		}
+	}
+	if best < 0 {
+		return nil, ""
+	}
+	donor := laid[best]
+	pts := donor.Line.Pts
+	arcA, _ := donor.Line.ProjectArc(a)
+	arcB, _ := donor.Line.ProjectArc(b)
+	if arcA > arcB { // donor runs the other way — ride it in reverse
+		rev := make([]geo.Pt, len(pts))
+		for i, q := range pts {
+			rev[len(pts)-1-i] = q
+		}
+		pts = rev
+	}
+	return pts, donor.Pattern.ShapeID
 }
 
 type matcher struct {
@@ -376,10 +525,17 @@ func (m *matcher) emitSample(pat gtfs.Pattern, q geo.Pt, i int, shape *geo.Line,
 	}
 }
 
-func (m *matcher) matchOne(pat gtfs.Pattern, frame geo.Frame) (Path, bool) {
-	pts := make([]geo.Pt, len(pat.Shape))
-	for i, ll := range pat.Shape {
-		pts[i] = frame.ToXY(ll)
+// matchOne matches one pattern. A non-empty guide replaces the pattern's
+// own shape as the DP's observation sequence (guideFor: an honest
+// sibling's already-matched path); the pattern's stops, service and
+// terminals are untouched — only the geometry the match chases changes.
+func (m *matcher) matchOne(pat gtfs.Pattern, frame geo.Frame, guide []geo.Pt) (Path, bool) {
+	pts := guide
+	if len(pts) < 2 {
+		pts = make([]geo.Pt, len(pat.Shape))
+		for i, ll := range pat.Shape {
+			pts[i] = frame.ToXY(ll)
+		}
 	}
 	shape := geo.NewLine(pts)
 	if shape.Len() < 2*m.p.SampleDs {

--- a/internal/stages/match_distrust_test.go
+++ b/internal/stages/match_distrust_test.go
@@ -1,0 +1,108 @@
+package stages
+
+import (
+	"math"
+	"testing"
+
+	"github.com/alexwohlbruck/portolan/internal/bundle"
+	"github.com/alexwohlbruck/portolan/internal/geo"
+	"github.com/alexwohlbruck/portolan/internal/gtfs"
+)
+
+// The Gold Runner problem in miniature: one straight 20 km track and
+// three patterns. Route GR has an honest decimated shape (five vertices,
+// all ON the steel) and a road-traced reverse twin running 2 km to the
+// side with five times the service. Route X has only the road tracing.
+// The liar with an honest sibling must ride the sibling's matched steel —
+// even though its own service weight would have matched it first — and
+// the liar without one must keep today's behavior and bridge its own
+// shape, because a lying shape with no honest sibling is still the only
+// geometry that exists. The decimated shape must not be flagged: its
+// vertices sit on the track, and chords are the confidence machinery's
+// business, not distrust's.
+func TestMatchDistrustsOffNetworkShapes(t *testing.T) {
+	frame := geo.NewFrame(geo.LL{})
+	var steel []geo.Pt
+	for x := 0.0; x <= 20000; x += 100 {
+		steel = append(steel, geo.Pt{X: x, Y: 0})
+	}
+	tracks := []bundle.Track{{ID: "way/steel", Line: geo.NewLine(steel)}}
+
+	lls := func(step, y float64, rev bool) []geo.LL {
+		var out []geo.LL
+		for x := 0.0; x <= 20000; x += step {
+			out = append(out, frame.ToLL(geo.Pt{X: x, Y: y}))
+		}
+		if rev {
+			for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+		return out
+	}
+	// terminals sit beside the steel, like platforms do
+	termA := frame.ToLL(geo.Pt{X: 0, Y: 40})
+	termB := frame.ToLL(geo.Pt{X: 20000, Y: 40})
+
+	honest := gtfs.Pattern{
+		Route: gtfs.Route{ID: "GR", Type: 2}, ShapeID: "honest", Trips: 2,
+		Shape: lls(5000, 0, false),
+		TermA: termA, TermB: termB, TermAID: "A", TermBID: "B",
+	}
+	liar := gtfs.Pattern{
+		Route: gtfs.Route{ID: "GR", Type: 2}, ShapeID: "road", Trips: 10,
+		Shape: lls(100, 2000, true),
+		TermA: termB, TermB: termA, TermAID: "B", TermBID: "A",
+	}
+	orphan := gtfs.Pattern{
+		Route: gtfs.Route{ID: "X", Type: 2}, ShapeID: "orphan", Trips: 3,
+		Shape: lls(100, 2000, false),
+		TermA: termA, TermB: termB, TermAID: "A", TermBID: "B",
+	}
+
+	paths, err := Match([]gtfs.Pattern{honest, liar, orphan}, tracks, frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byShape := map[string]Path{}
+	for _, p := range paths {
+		byShape[p.Pattern.ShapeID] = p
+	}
+	if len(byShape) != 3 {
+		t.Fatalf("want 3 paths, got %d", len(byShape))
+	}
+	gapless := func(p Path) bool {
+		for _, w := range p.WayIDs {
+			if w == "gap" {
+				return false
+			}
+		}
+		return true
+	}
+	maxY := func(p Path) float64 {
+		worst := 0.0
+		for _, q := range p.Line.Pts {
+			worst = math.Max(worst, math.Abs(q.Y))
+		}
+		return worst
+	}
+
+	h := byShape["honest"]
+	if h.Guide != "" || !gapless(h) || maxY(h) > 50 {
+		t.Fatalf("honest decimated shape must match its own steel ungapped: guide=%q maxY=%.0f", h.Guide, maxY(h))
+	}
+	l := byShape["road"]
+	if l.Guide != "honest" {
+		t.Fatalf("road tracing with an honest sibling must borrow its path, got guide=%q", l.Guide)
+	}
+	if !gapless(l) || maxY(l) > 50 {
+		t.Fatalf("guided pattern must ride the steel, not bridge the road: maxY=%.0f wayIDs=%v", maxY(l), l.WayIDs)
+	}
+	o := byShape["orphan"]
+	if o.Guide != "" || gapless(o) {
+		t.Fatalf("orphan road tracing has no donor and must keep bridging: guide=%q wayIDs=%v", o.Guide, o.WayIDs)
+	}
+	if maxY(o) < 1500 {
+		t.Fatalf("orphan bridge should carry its own shape geometry, maxY=%.0f", maxY(o))
+	}
+}

--- a/internal/stages/stages.go
+++ b/internal/stages/stages.go
@@ -33,6 +33,9 @@ type Path struct {
 	Line    *geo.Line
 	WayIDs  []string   // the OSM ways walked, in order ("gap" marks bridges)
 	Steps   []PathStep // the exact walk, for SPLIT
+	// Guide: the sibling shape whose matched path stood in for this
+	// pattern's own off-network shape ("" = matched on its own shape).
+	Guide string
 }
 
 // PathStep is one hop of a matched walk: a directed graph piece, or a gap


### PR DESCRIPTION
The Gold Runner drew sawtooth spaghetti between Stockton and Modesto — 15 km
straight chords across farmland, drawn as track. The cause was not the
matcher's DP and not the rail extract (the BNSF was present and three of the
route's four patterns rode it within 40 m). The fourth pattern's shape
(`703shape1`, Bakersfield→Sacramento, 2 trips) is road-traced garbage: **67%
of its arc has no rail within 90 m**, one 56 km stretch near Sacramento
never touches the network at all.

The gap law (LESSONS #8) rests on a premise: the shape is honest and OSM is
locally incomplete, so bridging with shape geometry is the least-wrong move.
A shape that is off-network for two-thirds of its length inverts that
premise — the track exists and the shape lies — and the matcher faithfully
drew the lie: a 1,511 km matched path for a 498 km route, 32 failed
flanked-gap walks with anchors up to 15.5 km apart, each one a straight
chord in the drawn map.

## The rule

Every shape is measured against the network before anything matches
(`offNetworkFrac`): the arc-weighted fraction of shape **vertices** with no
same-layer track within Reach. Vertices, not resampled chords, is the
discriminator — a decimated-but-honest shape parks every vertex on the
steel it means (the Gold Runner's sparse twins measure 0.4%), while a
road-traced shape parks vertex after vertex on asphalt. Honest shapes
measure ≤5% even where OSM drops whole branches.

Past `match_shape_distrust` (dial, 0.33) a shape loses its standing as
gap-bridging truth:

- it matches **last**, regardless of service weight, so the route's honest
  steel is already laid down;
- it borrows the matched path of an honest same-route sibling whose steel
  passes both its terminals (`guideFor`) — the reverse twin is the usual
  donor, reversed to ride in the pattern's direction;
- no donor → unchanged behavior. A lying shape with no honest sibling is
  still the only geometry that exists, and feeds whose OSM is genuinely
  missing keep bridging exactly as before.

Feeds where every shape is trusted keep their existing match order —
byte-identical builds.

## Observability

`paths.geojson` carries `guide: <shapeID>` when a swap happened, and
`PORTOLAN_DBGM=1` prints `DISTRUST GR 703shape1 off-network 64 % guide notx`.

## Result on sanjoaquins

- the distrusted pattern now matches to the identical 457 km path as its
  reverse twin (was 1,511 km with 35 gaps)
- SPLIT: 124 nodes / 151 edges of spaghetti → **6 nodes / 5 edges**
- FAIR: 1,153 segments → 32
- every remaining long straight segment sits within 6 m of the matched
  path — the Central Valley really is that straight

`TestMatchDistrustsOffNetworkShapes` is the case in miniature: one straight
track, an honest decimated shape, a road-traced twin with 5× the trips, and
an orphan liar with no donor. The twin must borrow despite its service
weight; the orphan must keep bridging; the decimated shape must not be
flagged. `make check` green, including the NYC diagnostics.