### PR TITLE
Bullets stay on their own line; terminal tails keep their hours

### DIFF
--- a/internal/pipeline/caterpillars.go
+++ b/internal/pipeline/caterpillars.go
@@ -159,6 +159,14 @@ const (
 	catStraightDeg   = 7.0 // max heading change across the chain window
 	catEndClearM     = 180.0
 	catStationClearM = 160.0
+	// Merging two chains is claiming they ride ONE corridor, so the test
+	// is corridor-shaped: generous along the travel direction (extents
+	// mismatch along the line), a bundle's width across it, and near-
+	// parallel tangents. catMergeCrossM absorbs the drift a straight-ish
+	// corridor accumulates between two anchors; the next street over is
+	// an order of magnitude farther out.
+	catMergeCrossM   = 25.0
+	catMergeAlignDot = 0.87 // cos ~30°: siblings run parallel, crossings do not
 )
 
 // bulletWidthPx mirrors the viewer's bulletCanvas: a circle for 1–2
@@ -633,14 +641,30 @@ func BuildCaterpillars(segs []stages.Segment, sts []Station, routes map[string]g
 		}
 		host := props[i]
 		mergeR := 60.0 + float64(len(host.roster))*20
+		// host travel frame in frame coords (+y north); tm is px-space
+		// (+y south), so y flips back
+		tf := geo.Pt{X: host.tm.X, Y: -host.tm.Y}
 		for j := i + 1; j < len(props); j++ {
 			if used[j] || props[j].band != host.band {
 				continue
 			}
-			if props[j].pt.Dist(host.pt) > mergeR {
+			// A plain radius here reached the next street over: the LIRR's
+			// roster grew mergeR past 150 m and its chain swallowed Fulton
+			// St's A/C whole (and the Lexington 4/5/6 the J). Decompose
+			// instead — far ALONG the corridor is the case this merge
+			// exists for, far ACROSS it is a different line.
+			d := props[j].pt.Sub(host.pt)
+			if math.Abs(d.Dot(tf)) > mergeR {
 				continue
 			}
-			flip := host.tm.Dot(props[j].tm) < 0
+			if math.Abs(d.X*tf.Y-d.Y*tf.X) > catMergeCrossM {
+				continue
+			}
+			dot := host.tm.Dot(props[j].tm)
+			if math.Abs(dot) < catMergeAlignDot {
+				continue // a crossing, not a sibling ribbon
+			}
+			flip := dot < 0
 			for _, e := range props[j].roster {
 				if flip {
 					e.lat = -e.lat

--- a/internal/pipeline/caterpillars_test.go
+++ b/internal/pipeline/caterpillars_test.go
@@ -1,0 +1,104 @@
+package pipeline
+
+import (
+	"math"
+	"testing"
+
+	"github.com/alexwohlbruck/portolan/internal/geo"
+	"github.com/alexwohlbruck/portolan/internal/gtfs"
+	"github.com/alexwohlbruck/portolan/internal/stages"
+)
+
+// catLine is a straight east-west polyline in frame metres at height y,
+// with a vertex every step so truncated twins hash differently.
+func catLine(x0, x1, y, step float64) *geo.Line {
+	var pts []geo.Pt
+	for x := x0; x <= x1; x += step {
+		pts = append(pts, geo.Pt{X: x, Y: y})
+	}
+	return geo.NewLine(pts)
+}
+
+// The merge that fuses one corridor's extent-mismatched chains must not
+// reach the next street over. At Franklin Av the LIRR's six-branch roster
+// grew the merge radius past the 150 m to Fulton St and its chain
+// swallowed the A/C whole — the bullets rode the Atlantic Branch. The
+// donor's chain is CONSUMED by a merge, so the failure is total: the
+// route's bullets appear only on the wrong line.
+func TestCaterpillarMergeStaysOnItsCorridor(t *testing.T) {
+	frame := geo.NewFrame(geo.LL{Lat: 40.68, Lon: -73.95})
+
+	routes := map[string]gtfs.Route{
+		"A": {ID: "A", ShortName: "A", Agency: "MTA"},
+		"C": {ID: "C", ShortName: "C", Agency: "MTA"},
+		"J": {ID: "J", ShortName: "J", Agency: "MTA"},
+		"M": {ID: "M", ShortName: "M", Agency: "MTA"},
+	}
+	branches := []string{"Babylon", "Hempstead", "West Hempstead", "Far Rockaway", "Long Beach", "Oyster Bay"}
+	var lirr []string
+	for _, b := range branches {
+		routes[b] = gtfs.Route{ID: b, LongName: b, Agency: "LI"}
+	}
+	for _, b := range branches {
+		lirr = append(lirr, b)
+	}
+
+	// Fulton St analog: a sibling pair on one exact geometry at y=0.
+	fulton := catLine(0, 3000, 0, 25)
+	// Atlantic Branch analog 150 m away — six word-label routes, so under
+	// the old point-radius rule its mergeR was 60+6*20=180 m. It sorts
+	// first (smaller Y), so it hosted.
+	atlantic := catLine(0, 3000, -150, 25)
+	// Same-corridor extent mismatch far away at y=600: twin centerlines
+	// whose cuts differ by 30 m. These SHOULD still fuse into one chain.
+	jLine := catLine(500, 2500, 600, 10)
+	mLine := catLine(530, 2500, 600, 10)
+
+	segs := []stages.Segment{
+		{Kind: "steady", Mode: "subway", BandMin: 15, Routes: []string{"A"}, OffsetPx: -2, Line: fulton},
+		{Kind: "steady", Mode: "subway", BandMin: 15, Routes: []string{"C"}, OffsetPx: 2, Line: fulton},
+		{Kind: "steady", Mode: "regional", BandMin: 15, Routes: lirr, OffsetPx: 0, Line: atlantic},
+		{Kind: "steady", Mode: "subway", BandMin: 15, Routes: []string{"J"}, OffsetPx: -2, Line: jLine},
+		{Kind: "steady", Mode: "subway", BandMin: 15, Routes: []string{"M"}, OffsetPx: 2, Line: mLine},
+	}
+
+	out := BuildCaterpillars(segs, nil, routes, frame)
+
+	groupsOf := map[string]map[int]bool{}
+	for _, b := range out {
+		if groupsOf[b.Route] == nil {
+			groupsOf[b.Route] = map[int]bool{}
+		}
+		groupsOf[b.Route][b.Group] = true
+		var wantY float64
+		switch b.Route {
+		case "A", "C":
+			wantY = 0
+		case "J", "M":
+			wantY = 600
+		default:
+			wantY = -150
+		}
+		if y := frame.ToXY(b.LL).Y; math.Abs(y-wantY) > 10 {
+			t.Errorf("route %s anchored at y=%.0f, its corridor is y=%.0f — riding another line", b.Route, y, wantY)
+		}
+	}
+	for _, r := range []string{"A", "C", "J", "M"} {
+		if len(groupsOf[r]) == 0 {
+			t.Errorf("route %s placed no bullets at all", r)
+		}
+	}
+	// The J and M are one corridor cut differently: some anchor must have
+	// fused them, or the cross-track gate is too tight and the clump the
+	// merge exists to fix is back.
+	fused := false
+	for g := range groupsOf["J"] {
+		if groupsOf["M"][g] {
+			fused = true
+			break
+		}
+	}
+	if !fused {
+		t.Errorf("J and M share a corridor but no chain carries both — same-corridor merge broke")
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -629,7 +629,7 @@ func layout(in layoutIn, logf func(string, ...any)) error {
 			terms[i][1] = frame.ToXY(pat.TermB)
 		}
 	}
-	segs = stages.CutSegmentsAtTerminals(segs, in.rail, terms)
+	segs = stages.CutSegmentsAtTerminals(segs, in.rail, terms, frame, o.BBox)
 	logf("terminal cuts: %d segments → %d (%.1fs)", nb, len(segs), time.Since(t0).Seconds())
 	if len(o.BBox) == 4 || len(o.Exclude) > 0 {
 		nb = len(segs)

--- a/internal/stages/terminal_cuts.go
+++ b/internal/stages/terminal_cuts.go
@@ -460,27 +460,33 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt,
 		// zeros — the weekend M's tail past Essex St is the Jamaica
 		// line's trackage, not the M's platform — and a window-clip end
 		// is a cut, not a terminus.
-		if pr != nil && len(pieces) > 1 {
-			inherit := func(pi int, outerArc, innerArc float64) {
+		if pr != nil {
+			inherit := func(pi int, outerArc float64, matches func(pathCover) bool) {
 				if nearClip(s.Line.AtArc(outerArc)) {
 					return
 				}
 				ns := &pieces[pi]
 				checked, dead := false, false
 				for ri := range s.Routes {
-					if !pr.trusted[ri] || ri >= len(ns.Acts) {
+					if !pr.trusted[ri] || ri >= len(ns.Acts) || ri >= len(orig) {
 						continue
 					}
 					if m, ok := gtfs.ParseMask168(ns.Acts[ri]); !ok || !m.Empty() {
 						continue
 					}
+					// refine-only, still: inherited hours may restore what
+					// the recompute took, never add what SPLIT had not
+					before, ok := gtfs.ParseMask168(orig[ri])
+					if !ok || before.Empty() {
+						continue
+					}
 					var inh gtfs.Mask168
 					for _, cv := range pr.covers[ri] {
-						if math.Abs(cv.a-innerArc) <= tcDedupeM+1 ||
-							math.Abs(cv.b-innerArc) <= tcDedupeM+1 {
+						if matches(cv) {
 							inh = inh.Or(cv.mask)
 						}
 					}
+					inh = inh.And(before)
 					if inh.Empty() {
 						continue
 					}
@@ -495,8 +501,28 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt,
 					anyDiffers = true
 				}
 			}
-			inherit(0, 0, bounds[1])
-			inherit(len(pieces)-1, L, bounds[len(bounds)-2])
+			if len(pieces) > 1 {
+				near := func(arc float64) func(pathCover) bool {
+					return func(cv pathCover) bool {
+						return math.Abs(cv.a-arc) <= tcDedupeM+1 ||
+							math.Abs(cv.b-arc) <= tcDedupeM+1
+					}
+				}
+				inherit(0, 0, near(bounds[1]))
+				inherit(len(pieces)-1, L, near(bounds[len(bounds)-2]))
+			} else if anyDiffers {
+				// The un-cuttable stub is the same case with no cut to
+				// anchor on: SPLIT bounded the platform piece with a
+				// junction of its own (Penn's ladder, the ACL throat at
+				// Philadelphia), the 120 m margins forbid any interior
+				// cut, and the pulled-back covers leave the midpoint dry —
+				// the recompute zeroes the whole piece. Every cover here
+				// is a train that reaches this piece, so at a dead end it
+				// keeps their union.
+				all := func(pathCover) bool { return true }
+				inherit(0, L, all)
+				inherit(0, 0, all)
+			}
 		}
 		if len(pieces) == 1 && !anyDiffers {
 			out = append(out, *s) // recompute matched the original — no-op

--- a/internal/stages/terminal_cuts.go
+++ b/internal/stages/terminal_cuts.go
@@ -41,6 +41,10 @@ const (
 	tcRideM    = 40.0  // a sample this close to a path counts as ridden
 	tcMarginM  = 120.0 // interior cuts keep clear of the segment ends
 	tcDedupeM  = 60.0  // cuts closer than this collapse into one
+	// dead-end test, same dials as the marker clamp in stations.go
+	tcTouchM = 25.0 // endpoint coincidence at a junction seam
+	tcProbeM = 60.0 // how far along a touching segment to look
+	tcAsideM = 30.0 // within this, a toucher is a sibling ending alongside
 )
 
 // pathCover is one pattern's coverage of one segment: the arc interval
@@ -87,7 +91,20 @@ func explains(acts []string, ri int, explained gtfs.Mask168) bool {
 // trackage (plus the trim margin), so the honest cut is at the stop —
 // the weekend M's drawn tail ends AT Essex St, not 300 m past it in
 // the junction throat. Zero points mean unknown; the path tip stands in.
-func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []Segment {
+//
+// frame and bbox mark window-cut line ends, exactly as in SnapStations:
+// a tail at the window edge is a clip, not a terminus, and never
+// inherits hours.
+func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt,
+	frame geo.Frame, bbox []float64) []Segment {
+	nearClip := func(p geo.Pt) bool { return false }
+	if len(bbox) == 4 {
+		nearClip = func(p geo.Pt) bool {
+			ll := frame.ToLL(p)
+			return ll.Lon < bbox[0]-0.015 || ll.Lon > bbox[2]+0.015 ||
+				ll.Lat < bbox[1]-0.015 || ll.Lat > bbox[3]+0.015
+		}
+	}
 	if patternActs == nil {
 		return segs
 	}
@@ -319,6 +336,66 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 		prepBySeg[prep[i].si] = &prep[i]
 	}
 
+	// Continuation index for the dead-end test: band+route → segments
+	// that could carry the line onward. Transitions count — consecutive
+	// steady pieces do not touch at junctions, the transition bridges
+	// the seam, and without them every junction seam reads as a dead
+	// end (the marker clamp in stations.go learned the same lesson).
+	type bandRoute struct {
+		band  int
+		route string
+	}
+	cont := map[bandRoute][]int{}
+	for i := range segs {
+		s := &segs[i]
+		if s.Line == nil {
+			continue
+		}
+		switch s.Kind {
+		case "steady", "bridge", "transition":
+		default:
+			continue
+		}
+		for _, r := range s.Routes {
+			k := bandRoute{s.BandMin, r}
+			cont[k] = append(cont[k], i)
+		}
+	}
+	// deadEnd reports whether the segment's end at endArc is a true tip
+	// of these routes' network: nothing carrying them touches the end
+	// point and leads away. A sibling ribbon ending alongside is the
+	// bundle's own tip, not a way out.
+	deadEnd := func(si int, endArc float64) bool {
+		s := &segs[si]
+		endPt := s.Line.AtArc(endArc)
+		for _, r := range s.Routes {
+			for _, sj := range cont[bandRoute{s.BandMin, r}] {
+				if sj == si {
+					continue
+				}
+				o := segs[sj].Line
+				tArc := -1.0
+				if o.Pts[0].Dist(endPt) < tcTouchM {
+					tArc = 0
+				} else if o.Pts[len(o.Pts)-1].Dist(endPt) < tcTouchM {
+					tArc = o.Len()
+				}
+				if tArc < 0 {
+					continue
+				}
+				probeArc := math.Min(tcProbeM, o.Len())
+				if tArc > 0 {
+					probeArc = math.Max(0, o.Len()-tcProbeM)
+				}
+				if _, d := s.Line.ProjectArc(o.AtArc(probeArc)); d < tcAsideM {
+					continue // ending alongside, not leading away
+				}
+				return false
+			}
+		}
+		return true
+	}
+
 	for si := range segs {
 		s := &segs[si]
 		if (s.Kind != "steady" && s.Kind != "bridge") || s.Line == nil {
@@ -366,15 +443,60 @@ func CutSegmentsAtTerminals(segs []Segment, paths []Path, terms [][2]geo.Pt) []S
 					}
 				}
 			}
-			// tail pieces with all-zero hours are KEPT (dark under any
-			// timestamp, visible on the union): at terminals like
-			// Atlantic the "overshoot" is the platforms themselves —
-			// the GTFS stop point sits at one end of them — and the
-			// terminus clamp walks the chain to cap the true tip.
 			ns := *s
 			ns.Acts = acts
 			ns.Line = subLine(s.Line, lo, hi)
 			pieces = append(pieces, ns)
+		}
+		// A terminating pattern OCCUPIES its overshoot: the piece past
+		// the last stop is the platforms at Atlantic Terminal, the relay
+		// tail at Rockaway Blvd — trackage its trains stand on whenever
+		// they run. The recompute zeroes that tail, and a zero tail at
+		// the line's true tip opens a gap under any service-time filter,
+		// because the marker clamp has put the station dot at the drawn
+		// tip and the ink now stops short of it. So a zero-hour TAIL at
+		// a DEAD END inherits the hours of the covers ending at its
+		// boundary cut. A tail that continues into a junction keeps its
+		// zeros — the weekend M's tail past Essex St is the Jamaica
+		// line's trackage, not the M's platform — and a window-clip end
+		// is a cut, not a terminus.
+		if pr != nil && len(pieces) > 1 {
+			inherit := func(pi int, outerArc, innerArc float64) {
+				if nearClip(s.Line.AtArc(outerArc)) {
+					return
+				}
+				ns := &pieces[pi]
+				checked, dead := false, false
+				for ri := range s.Routes {
+					if !pr.trusted[ri] || ri >= len(ns.Acts) {
+						continue
+					}
+					if m, ok := gtfs.ParseMask168(ns.Acts[ri]); !ok || !m.Empty() {
+						continue
+					}
+					var inh gtfs.Mask168
+					for _, cv := range pr.covers[ri] {
+						if math.Abs(cv.a-innerArc) <= tcDedupeM+1 ||
+							math.Abs(cv.b-innerArc) <= tcDedupeM+1 {
+							inh = inh.Or(cv.mask)
+						}
+					}
+					if inh.Empty() {
+						continue
+					}
+					if !checked {
+						dead = deadEnd(si, outerArc)
+						checked = true
+					}
+					if !dead {
+						return
+					}
+					ns.Acts[ri] = inh.Hex()
+					anyDiffers = true
+				}
+			}
+			inherit(0, 0, bounds[1])
+			inherit(len(pieces)-1, L, bounds[len(bounds)-2])
 		}
 		if len(pieces) == 1 && !anyDiffers {
 			out = append(out, *s) // recompute matched the original — no-op

--- a/internal/stages/terminal_cuts_test.go
+++ b/internal/stages/terminal_cuts_test.go
@@ -46,7 +46,7 @@ func TestCutSegmentsAtTerminals(t *testing.T) {
 		{Pattern: short, Line: line(-500, 700)}, // terminates 700 m in
 		{Pattern: tip, Line: line(1950, 2500)},  // tip-touches the far end
 	}
-	out := CutSegmentsAtTerminals([]Segment{seg}, paths, nil)
+	out := CutSegmentsAtTerminals([]Segment{seg}, paths, nil, geo.Frame{}, nil)
 	if len(out) != 2 {
 		t.Fatalf("want 2 pieces, got %d: %+v", len(out), out)
 	}
@@ -79,7 +79,7 @@ func TestCutsKeepUnmaskedRoutesIntact(t *testing.T) {
 	seg := Segment{Kind: "steady", Routes: []string{"X"},
 		Acts: []string{"deadbeef"}, Line: line(0, 2000)}
 	paths := []Path{{Pattern: gtfs.Pattern{Route: gtfs.Route{ID: "X"}, ShapeID: "s"}, Line: line(-100, 900)}}
-	out := CutSegmentsAtTerminals([]Segment{seg}, paths, nil)
+	out := CutSegmentsAtTerminals([]Segment{seg}, paths, nil, geo.Frame{}, nil)
 	if len(out) != 1 || out[0].Acts[0] != "deadbeef" {
 		t.Fatalf("unmasked route must pass through untouched: %+v", out)
 	}
@@ -113,7 +113,7 @@ func TestCutsSynchronizeAcrossRibbons(t *testing.T) {
 		{Pattern: mShort, Line: line(-500, 700)},
 		{Pattern: jFull, Line: line(-500, 2500)},
 	}
-	out := CutSegmentsAtTerminals([]Segment{jSeg, mSeg}, paths, nil)
+	out := CutSegmentsAtTerminals([]Segment{jSeg, mSeg}, paths, nil, geo.Frame{}, nil)
 	if len(out) != 4 {
 		t.Fatalf("both ribbons must split identically: want 4 pieces, got %d", len(out))
 	}
@@ -129,11 +129,12 @@ func TestCutsSynchronizeAcrossRibbons(t *testing.T) {
 	}
 }
 
-// A tail beyond the terminal stop that NO pattern rides is KEPT but
-// carries zero hours: at real terminals the "overshoot" is often the
-// platforms themselves, so the geometry stays (the terminus clamp caps
-// its tip) while any timestamp renders it dark.
-func TestRelayTailGoesDark(t *testing.T) {
+// A tail beyond the terminal stop at the line's TRUE TIP keeps its
+// terminating pattern's hours: the overshoot is the platforms (Atlantic
+// Terminal) or the relay track its trains stand on, the marker clamp
+// puts the station dot at the drawn tip, and a zero-hour tail there
+// opens a gap between ink and dot under any service-time filter.
+func TestDeadEndTailKeepsTerminatorHours(t *testing.T) {
 	line := func(x0, x1 float64) *geo.Line {
 		var pts []geo.Pt
 		for x := x0; x <= x1; x += 50 {
@@ -152,7 +153,7 @@ func TestRelayTailGoesDark(t *testing.T) {
 	// whole) but the terminal STOP is at 1600 — the last 400 m is tail
 	paths := []Path{{Pattern: pat, Line: line(-500, 2000)}}
 	terms := [][2]geo.Pt{{{X: -500, Y: 0}, {X: 1600, Y: 0}}}
-	out := CutSegmentsAtTerminals([]Segment{seg}, paths, terms)
+	out := CutSegmentsAtTerminals([]Segment{seg}, paths, terms, geo.Frame{}, nil)
 	if len(out) != 2 {
 		t.Fatalf("want 2 pieces (tail kept), got %d", len(out))
 	}
@@ -162,8 +163,52 @@ func TestRelayTailGoesDark(t *testing.T) {
 	if out[0].Acts[0] != day.Hex() {
 		t.Fatalf("service piece acts: %s", out[0].Acts[0])
 	}
-	if m, ok := gtfs.ParseMask168(out[1].Acts[0]); !ok || !m.Empty() {
-		t.Fatalf("tail must carry ZERO hours: %s", out[1].Acts[0])
+	if out[1].Acts[0] != day.Hex() {
+		t.Fatalf("dead-end tail must keep its terminator's hours: %s", out[1].Acts[0])
+	}
+}
+
+// ...but a tail that CONTINUES into a junction stays dark outside its
+// patterns' hours — the weekend M's tail past Essex St is the Jamaica
+// line's trackage, not the M's platform. The same cut as above, with
+// the route carrying on beyond the segment end.
+func TestJunctionTailGoesDark(t *testing.T) {
+	line := func(x0, x1 float64) *geo.Line {
+		var pts []geo.Pt
+		for x := x0; x <= x1; x += 50 {
+			pts = append(pts, geo.Pt{X: x, Y: 0})
+		}
+		return geo.NewLine(pts)
+	}
+	pat := gtfs.Pattern{Route: gtfs.Route{ID: "L"}, ShapeID: "s"}
+	var day gtfs.Mask168
+	day = day.Set(0, 9)
+	SetPatternActs(map[string]gtfs.Mask168{"L\x1fs": day})
+	defer SetPatternActs(nil)
+	seg := Segment{Kind: "steady", Routes: []string{"L"},
+		Acts: []string{day.Hex()}, Line: line(0, 2000)}
+	// the route leaves the segment end heading north: a continuation,
+	// so the end is a junction seam, not a terminus
+	var north []geo.Pt
+	for y := 0.0; y <= 600; y += 50 {
+		north = append(north, geo.Pt{X: 2000, Y: y})
+	}
+	cont := Segment{Kind: "steady", Routes: []string{"L"},
+		Acts: []string{day.Hex()}, Line: geo.NewLine(north)}
+	paths := []Path{{Pattern: pat, Line: line(-500, 2000)}}
+	terms := [][2]geo.Pt{{{X: -500, Y: 0}, {X: 1600, Y: 0}}}
+	out := CutSegmentsAtTerminals([]Segment{seg, cont}, paths, terms, geo.Frame{}, nil)
+	var tail *Segment
+	for i := range out {
+		if out[i].Line.Len() < 500 && math.Abs(out[i].Line.Pts[0].Y) < 1 {
+			tail = &out[i]
+		}
+	}
+	if tail == nil {
+		t.Fatalf("tail piece missing: %d pieces", len(out))
+	}
+	if m, ok := gtfs.ParseMask168(tail.Acts[0]); !ok || !m.Empty() {
+		t.Fatalf("junction tail must carry ZERO hours: %s", tail.Acts[0])
 	}
 }
 
@@ -195,7 +240,7 @@ func TestCutsPullBackToTerminalStop(t *testing.T) {
 		{},                                // full: unknown ends (far away anyway)
 		{{X: -500, Y: 0}, {X: 700, Y: 0}}, // short: terminal STOP at x=700
 	}
-	out := CutSegmentsAtTerminals([]Segment{seg}, paths, terms)
+	out := CutSegmentsAtTerminals([]Segment{seg}, paths, terms, geo.Frame{}, nil)
 	if len(out) != 2 {
 		t.Fatalf("want 2 pieces, got %d", len(out))
 	}
@@ -252,7 +297,7 @@ func TestCutsKeepHoursNoPatternCanExplain(t *testing.T) {
 		// the rush pattern short-turns 700 m in and does ride the line
 		{Pattern: rush, Line: line(-500, 700, 0)},
 	}
-	out := CutSegmentsAtTerminals([]Segment{seg}, paths, nil)
+	out := CutSegmentsAtTerminals([]Segment{seg}, paths, nil, geo.Frame{}, nil)
 	for _, sg := range out {
 		if sg.Acts[0] != always.Hex() {
 			t.Fatalf("a 24/7 railway lost its hours to a rush-only pattern: %s", sg.Acts[0])
@@ -262,7 +307,7 @@ func TestCutsKeepHoursNoPatternCanExplain(t *testing.T) {
 	// and once that pattern is back ON the centerline, refinement runs
 	// again: the far piece keeps only the all-day hours
 	paths[0].Line = line(-500, 2500, 0)
-	out = CutSegmentsAtTerminals([]Segment{seg}, paths, nil)
+	out = CutSegmentsAtTerminals([]Segment{seg}, paths, nil, geo.Frame{}, nil)
 	if len(out) != 2 {
 		t.Fatalf("want 2 pieces once reconstructible, got %d", len(out))
 	}

--- a/internal/stages/terminal_cuts_test.go
+++ b/internal/stages/terminal_cuts_test.go
@@ -168,6 +168,39 @@ func TestDeadEndTailKeepsTerminatorHours(t *testing.T) {
 	}
 }
 
+// The un-cuttable stub: SPLIT bounded the platform piece with its own
+// junction (Penn's ladder), the margins forbid any interior cut, and the
+// cover pulled back to a stop near the piece's start leaves the midpoint
+// dry — the whole single piece recomputes to zero. At a dead end it must
+// keep its covers' hours instead.
+func TestUncuttableStubKeepsHours(t *testing.T) {
+	line := func(x0, x1 float64) *geo.Line {
+		var pts []geo.Pt
+		for x := x0; x <= x1; x += 25 {
+			pts = append(pts, geo.Pt{X: x, Y: 0})
+		}
+		return geo.NewLine(pts)
+	}
+	pat := gtfs.Pattern{Route: gtfs.Route{ID: "L"}, ShapeID: "s"}
+	var day gtfs.Mask168
+	day = day.Set(0, 9)
+	SetPatternActs(map[string]gtfs.Mask168{"L\x1fs": day})
+	defer SetPatternActs(nil)
+	// 200 m platform piece; the path tip lands 150 m in, its terminal
+	// STOP projects 30 m in — inside the 120 m cut margin, so no cut
+	seg := Segment{Kind: "steady", Routes: []string{"L"},
+		Acts: []string{day.Hex()}, Line: line(0, 200)}
+	paths := []Path{{Pattern: pat, Line: line(-500, 150)}}
+	terms := [][2]geo.Pt{{{X: -500, Y: 0}, {X: 30, Y: 0}}}
+	out := CutSegmentsAtTerminals([]Segment{seg}, paths, terms, geo.Frame{}, nil)
+	if len(out) != 1 {
+		t.Fatalf("want 1 piece (no room to cut), got %d", len(out))
+	}
+	if out[0].Acts[0] != day.Hex() {
+		t.Fatalf("dead-end stub must keep its covers' hours: %s", out[0].Acts[0])
+	}
+}
+
 // ...but a tail that CONTINUES into a junction stays dark outside its
 // patterns' hours — the weekend M's tail past Essex St is the Jamaica
 // line's trackage, not the M's platform. The same cut as above, with


### PR DESCRIPTION
Two service-display bugs seen on the northeast-corridor build, both fixed at the root.

## Caterpillar chains merged across the street

At Franklin Av the A/C bullets rode the LIRR Atlantic Branch; at City Hall the J sat on the Lexington 4/5/6. The chain merge in `BuildCaterpillars` fused any two same-band chains whose anchors were within `60 + 20×roster` metres **by plain point distance** — the LIRR's six-branch roster grew that radius past the 150 m to Fulton St, swallowed the A/C chains whole, and a swallowed chain is consumed, so the stolen bullets existed only on the wrong line.

The gate is now corridor-shaped: the offset decomposes in the host's travel frame — `mergeR` **along** the corridor (the extent-mismatch case the merge exists for), ≤25 m **across** it, tangents within ~30° so crossings can't fuse. `TestCaterpillarMergeStaysOnItsCorridor` rebuilds the Franklin Av layout synthetically and fails on the old gate with exactly the reported symptom.

## Terminal tails went dark under a service-time filter

With no timestamp the LIRR reached Atlantic Terminal's dot; with one set, the line stopped 183 m short. Terminal cuts zeroed the tail piece past the last stop, while the marker clamp puts the station dot at the drawn tip — so any filter opened a gap between ink and dot.

A terminating pattern **occupies** its overshoot — the tail is the platforms at Atlantic, the relay track at Rockaway Blvd. Two anatomies, both fixed:

- **Cut tail** — a zero-hour tail piece at the line's true tip inherits the hours of the covers ending at its boundary cut.
- **Un-cuttable stub** — SPLIT bounded the platform piece with a junction of its own (Penn's ladder, the ACL throat at Philadelphia), the 120 m margins forbid any interior cut, and the pulled-back covers leave the midpoint dry, zeroing the whole single piece. It inherits the union of its covers.

Both apply only at a true **dead end** (continuation test with the marker clamp's dials, transitions included so junction seams don't read as termini) and are capped `And(original)` — refine-only, never adding hours SPLIT had not attested. Tails that continue into a junction keep their zeros (the weekend M's tail past Essex St is the Jamaica line's trackage, not the M's platform), and window-clip ends are cuts, not termini.

`TestRelayTailGoesDark` encoded the old policy and is rewritten as `TestDeadEndTailKeepsTerminatorHours`; `TestJunctionTailGoesDark` and `TestUncuttableStubKeepsHours` pin the dark and lit cases.

## Verified

Full northeast-corridor group rebuild with all three commits: A/C chains carry both letters on the Fulton St line with the LIRR branch names on their own corridor; the Atlantic Terminal stub carries all seven branches' real hours; the Penn Station ladder piece and the Atlantic City Line's Philadelphia stub clear too. A sweep for features invisible under every timestamp went 13 → 5; the survivors are `transition` connectors whose two edges' masks are honestly disjoint (`And` semantics in FAIR), a different mechanism left alone. `go vet ./... && go test ./...` green.