### PR TITLE
refine: folds are impossible, not merely expensive

### DIFF
--- a/internal/bundle/centerline.go
+++ b/internal/bundle/centerline.go
@@ -612,21 +612,30 @@ func Refine(cl *geo.Line, members []*geo.Line, p Params) *geo.Line {
 		// Eberswalder drew 175° reversal knots from exactly this — MATCH
 		// clean, votes stable, geometry folded). Clamp to 0.8R; the
 		// gaussian and slope limit below ramp the clamped pockets.
-		if p.SwitchTolerant {
-			for i := 1; i < n-1; i++ {
-				if !has[i] || filt[i] == 0 {
-					continue
-				}
-				a, b, c := pts[i-1], pts[i], pts[i+1]
-				ab, bc, ca := a.Dist(b), b.Dist(c), c.Dist(a)
-				// 4*area via cross product; R = abc/(4K), huge when collinear
-				k4 := 2 * math.Abs((b.X-a.X)*(c.Y-a.Y)-(b.Y-a.Y)*(c.X-a.X))
-				if k4 < 1e-9 {
-					continue
-				}
-				if lim := 0.8 * ab * bc * ca / k4; math.Abs(filt[i]) > lim {
-					filt[i] = math.Copysign(lim, filt[i])
-				}
+		//
+		// EVERY mode, not just street. The fold is a property of offset
+		// against curvature, not of what runs on the rail: a metro vote
+		// flap that survives the majority window folds exactly the same
+		// way (an authored Chicago Green seeded its scramble at the
+		// first curve its wave crossed), and once one fold exists the
+		// next iteration inherits it as base geometry. This clamp is
+		// also what makes refinement SELF-STABILIZING: a wiggle that
+		// does form gives the line small local radii, which clamp the
+		// following iteration's offsets toward zero instead of feeding
+		// them.
+		for i := 1; i < n-1; i++ {
+			if !has[i] || filt[i] == 0 {
+				continue
+			}
+			a, b, c := pts[i-1], pts[i], pts[i+1]
+			ab, bc, ca := a.Dist(b), b.Dist(c), c.Dist(a)
+			// 4*area via cross product; R = abc/(4K), huge when collinear
+			k4 := 2 * math.Abs((b.X-a.X)*(c.Y-a.Y)-(b.Y-a.Y)*(c.X-a.X))
+			if k4 < 1e-9 {
+				continue
+			}
+			if lim := 0.8 * ab * bc * ca / k4; math.Abs(filt[i]) > lim {
+				filt[i] = math.Copysign(lim, filt[i])
 			}
 		}
 		// Stiffness scales with corridor width. On a wide interlocking
@@ -669,6 +678,15 @@ func Refine(cl *geo.Line, members []*geo.Line, p Params) *geo.Line {
 			}
 			out[i] = pts[i].Add(nrm.Scale(o))
 		}
+		// The moved line must not contain fold knots before the finish
+		// smoother sees it: SmoothTurning keeps segment lengths, so a
+		// 150° reversal knot survives smoothing as a curl and is base
+		// geometry for the next iteration. The radius clamp above makes
+		// folds rare; it cannot make them impossible (it bounds the
+		// offset against the BASE line's curvature, and a varying
+		// offset series adds curvature of its own), so enforce the
+		// invariant directly — steel never turns 90° in one 6 m step.
+		out = geo.Unfold(out, 90)
 		// Finish smoothing runs in the TURNING-ANGLE domain
 		// (geo.SmoothTurning): smoothing POSITIONS is curvature-biased
 		// and pulled ~8 m off the SW Loop's R17 corner over five passes,
@@ -688,16 +706,24 @@ func Refine(cl *geo.Line, members []*geo.Line, p Params) *geo.Line {
 		// samples whose normals flip across it, and `moved` never drops
 		// below the convergence break while the vote set is unstable. On
 		// a game-authored NYC (two directional strands breathing 5–22 m
-		// apart under a metro edge, which has no radius clamp) five
+		// apart under a metro edge, which then had no radius clamp) five
 		// iterations per call across six refine calls took the 1's
 		// 12 km corridor to 766 km of scribble between 137 St and
 		// 145 St. Growth IS the fold signature, so gate on it directly:
-		// keep the last stable line and stop. The 2% + 30 m allowance
-		// clears every legitimate call measured (a full NYC build's
-		// biggest honest iteration moves total length 0.05%) and the
-		// free-end tip correction, which extends arc by probe-span
-		// metres, not by percent.
-		if next.Len() > cur.Len()*1.02+30 {
+		// keep the last stable line and stop.
+		//
+		// The allowance is ABSOLUTE, deliberately not a percentage. A
+		// fold is local — a few hundred metres of knot in one spot — so
+		// a percentage scales the leak with edge length: 2% of an
+		// authored Chicago Green's 35.8 km megachain let ~700 m of
+		// scramble through per call and the calls compound. Honest
+		// growth does not scale with length at all: centering moves
+		// sideways (a full NYC build's biggest honest iteration moves
+		// total length 0.05%), and the one legitimate arc-adding move,
+		// the free-end tip correction, is bounded by SpanProbe metres
+		// per end. 2×SpanProbe covers both ends with the measured
+		// honest-growth margin underneath it.
+		if next.Len() > cur.Len()+2*p.SpanProbe {
 			break
 		}
 		cur = next

--- a/internal/bundle/centerline_test.go
+++ b/internal/bundle/centerline_test.go
@@ -166,4 +166,12 @@ func TestRefineNeverGrowsTheLine(t *testing.T) {
 		t.Fatalf("refinement grew the line: %.0f m in, %.0f m out (limit %.0f)",
 			cl.Len(), got.Len(), lim)
 	}
+	// and the line that comes back contains no fold knots — the length
+	// gate bounds the damage, the unfold pass removes it. An authored
+	// Chicago Green showed why both matter: on a 35.8 km megachain a
+	// percentage-sized length allowance passed ~700 m of local knots per
+	// call while total growth stayed "small".
+	if turn := geo.MaxTurnDeg(got.Pts); turn > 90 {
+		t.Fatalf("refinement left a fold knot: max turn %.0f°", turn)
+	}
 }

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -279,6 +279,43 @@ func TurnDeg(a, b, c Pt) float64 {
 	return math.Acos(d) * 180 / math.Pi
 }
 
+// Unfold removes fold knots: interior vertices whose turn exceeds
+// maxDeg. At the sampling steps this codebase draws at (metres, not
+// tens of metres), no physical railway turns 90° at a single vertex —
+// the tightest steel on earth (a ~15 m tram curve) reads ~25° per
+// vertex at a 6 m step. A sharper turn is always an artifact: a
+// refinement offset that outran its base line's curvature, a weld
+// seam pointing at a stale node, a lens midline crossing its pair.
+// Deleting the vertex collapses the knot onto its chord, which is the
+// same answer the vote-blanking machinery gives an unstable pocket —
+// bridge it straight — applied in position space. Endpoints are never
+// touched. Runs to a fixpoint: a multi-vertex curl exposes a new
+// reversal each time its tip is cut, so one pass is not enough; the
+// pass cap only bounds the pathological all-knot line.
+func Unfold(pts []Pt, maxDeg float64) []Pt {
+	for pass := 0; pass < 16; pass++ {
+		if len(pts) < 3 {
+			return pts
+		}
+		out := pts[:0:0]
+		out = append(out, pts[0])
+		changed := false
+		for i := 1; i < len(pts)-1; i++ {
+			if TurnDeg(out[len(out)-1], pts[i], pts[i+1]) > maxDeg {
+				changed = true
+				continue
+			}
+			out = append(out, pts[i])
+		}
+		out = append(out, pts[len(pts)-1])
+		pts = out
+		if !changed {
+			return pts
+		}
+	}
+	return pts
+}
+
 // SmoothTurning low-passes a polyline in the TURNING-ANGLE domain: it
 // smooths the sequence of segment headings over arc length and rebuilds
 // the line from the smoothed headings, keeping every segment's length.

--- a/internal/geo/geo_test.go
+++ b/internal/geo/geo_test.go
@@ -1,0 +1,32 @@
+package geo
+
+import (
+	"math"
+	"testing"
+)
+
+func TestUnfoldCutsKnotsKeepsCurves(t *testing.T) {
+	// A genuine tight curve at drawing resolution: 90° over six vertices
+	// (15°/vertex — sharper than any real steel reads at a 6 m step).
+	var curve []Pt
+	for i := 0; i <= 6; i++ {
+		th := float64(i) * math.Pi / 2 / 6
+		curve = append(curve, Pt{X: 20 * math.Sin(th), Y: 20 - 20*math.Cos(th)})
+	}
+	if got := Unfold(curve, 90); len(got) != len(curve) {
+		t.Fatalf("unfold ate a legitimate curve: %d -> %d vertices", len(curve), len(got))
+	}
+
+	// A fold curl: the line doubles back on itself mid-run — three
+	// vertices of ~150° reversal, the exact knot a refinement offset
+	// that outran its base curvature leaves behind.
+	fold := []Pt{{0, 0}, {10, 0}, {20, 0}, {24, 1}, {16, 3}, {25, 5}, {30, 0}, {40, 0}, {50, 0}}
+	got := Unfold(fold, 90)
+	if MaxTurnDeg(got) > 90 {
+		t.Fatalf("knot survived: max turn %.0f°", MaxTurnDeg(got))
+	}
+	// endpoints are never touched
+	if got[0] != fold[0] || got[len(got)-1] != fold[len(fold)-1] {
+		t.Fatalf("unfold moved an endpoint")
+	}
+}

--- a/internal/stages/split.go
+++ b/internal/stages/split.go
@@ -130,7 +130,17 @@ func dbgNet(tag string, net *Network) {
 			L += geo.NewLine(e.Pts).Len()
 		}
 	}
-	fmt.Printf("DBGNET %-14s %3d edges %8.0f m\n", tag, len(net.Edges), L)
+	knots := 0
+	for _, e := range net.Edges {
+		for i := 2; i < len(e.Pts); i++ {
+			a := e.Pts[i-1].Sub(e.Pts[i-2])
+			b := e.Pts[i].Sub(e.Pts[i-1])
+			if a.Norm() > 0 && b.Norm() > 0 && a.Unit().Dot(b.Unit()) < 0 {
+				knots++
+			}
+		}
+	}
+	fmt.Printf("DBGNET %-14s %3d edges %8.0f m %5d knots>90\n", tag, len(net.Edges), L, knots)
 }
 func Split(paths []Path, tracks []bundle.Track) (*Network, error) {
 	setLevelIndex(tracks)
@@ -712,6 +722,19 @@ func Split(paths []Path, tracks []bundle.Track) (*Network, error) {
 	}
 	trimEdgeEnds(net)
 	compactNodes(net)
+	// The last line of defense, and an INVARIANT rather than a repair:
+	// no edge leaves SPLIT with a fold knot. Refine unfolds its own
+	// output, but it is not the only writer of edge geometry — seam
+	// blends, node welds, end trims and lens midlines all move vertices
+	// after the last refine — and FAIR densifies whatever survives here
+	// into drawn ink. Steel never turns 90° at one vertex at these
+	// sampling steps; anything that does is an artifact, whoever made it.
+	for ei := range net.Edges {
+		e := &net.Edges[ei]
+		if len(e.Pts) >= 3 {
+			e.Pts = geo.Unfold(e.Pts, 90)
+		}
+	}
 	dbgNet("final", net)
 	return net, nil
 }


### PR DESCRIPTION
Second scramble, this time on an authored Chicago save — the Green drawing 13.5 km of curls over four blocks at Cermak (73,076° of turning in the box). Same vote-flap instability as NYC's, but it slipped both 0.4.1 guards, and since players can author any geometry imaginable the fix this time is an invariant, not a tighter budget.

- The growth gate allowed 2% of the line, and a fold is local: on the Green's 35.8 km megachain that passed ~700 m of knots per call while total growth stayed "small". The allowance is now absolute — 2×SpanProbe, the bound on the one legitimate arc-adding move (free-end tip correction); honest growth measured 0.05% of total
- The 0.8R turn-radius clamp (built for Berlin M1's reversal knots) ran only for street edges; it runs for every mode now. It also makes refinement self-stabilizing — a wiggle gives the line small local radii, which clamp the next iteration's offsets toward zero
- Neither gate can make folds impossible, so the invariant is enforced directly: at metre-scale sampling no physical railway turns 90° at one vertex (~25°/vertex is the tightest steel on earth at a 6 m step), and a genuine switchback is a node between edges, never an interior vertex. `geo.Unfold` deletes interior vertices past 90°, collapsing each knot onto its chord
- Unfold runs twice: Refine unfolds its own moved line each iteration, and Split unfolds every edge as its last act — seam blends, node welds, end trims and lens midlines all write geometry after the last refine, so no edge leaves SPLIT folded whoever made it
- `dbgNet` now counts reversal knots per phase; the Chicago hunt needed exactly that number and had to add it by hand

Measured on the failing save: the Cermak box 73,076° → 858°, all real curves; knots at every phase zero. The NYC save holds its 0.4.1 numbers (2 Av 1,918°, the 1's corridor 106°).

Verified: full suite green, 15 packages. New `geo.Unfold` contract test and a knot assertion on the NYC fold fixture — removed the unfold call to check they bite: fail.