### PR TITLE
atlas: drag-and-drop Subway Builder .metro saves onto the console

### DIFF
--- a/internal/atlas/atlas.go
+++ b/internal/atlas/atlas.go
@@ -81,6 +81,8 @@ type Server struct {
 
 	locMu sync.Mutex
 
+	importMu sync.Mutex // one .metro import at a time — the script rewrites portolan.json
+
 	runMu   sync.Mutex
 	running bool
 	runLog  []string
@@ -368,6 +370,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/style/config", s.styleConfigAPI)
 	mux.HandleFunc("/api/routes", s.routesAPI)
 	mux.HandleFunc("/console/", s.console)
+	mux.HandleFunc("/api/import/metro", s.importMetro)
 	mux.HandleFunc("/api/run", s.run)
 	mux.HandleFunc("/api/run/status", s.runStatus)
 	mux.HandleFunc("/api/score", s.score)

--- a/internal/atlas/importmetro.go
+++ b/internal/atlas/importmetro.go
@@ -1,0 +1,153 @@
+package atlas
+
+// /api/import/metro — drop a Subway Builder .metro save on the console and
+// it becomes a feed.
+//
+// The conversion itself does NOT live here. A .metro save is the game's
+// container, and the only faithful serializer is the game's own adapter
+// (exportFeed — the exact GTFS + rail + curation doc the game hands the
+// engine at runtime). So this handler shells out to the game repo's
+// importer script, which parses the save, runs exportFeed, writes
+// data/sb/<key>/ + style/<key>.json into THIS checkout and registers the
+// feed in portolan.json. config() picks the new entry up on its own
+// (portolan.json is re-read on mtime change); the console then charts it
+// like any other city.
+//
+// The script is found at ../metro-maker4/next-app-2/scripts/
+// metro-to-portolan.ts relative to this checkout — the mirror image of the
+// game's own "../../portolan" default — or wherever SB_METRO_IMPORTER
+// points. No game checkout, no endpoint: 501 with instructions.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// importerScript resolves the game-side converter, env override first.
+func (s *Server) importerScript() (string, error) {
+	if p := os.Getenv("SB_METRO_IMPORTER"); p != "" {
+		if _, err := os.Stat(p); err != nil {
+			return "", fmt.Errorf("SB_METRO_IMPORTER=%s: %w", p, err)
+		}
+		return p, nil
+	}
+	cfgAbs, err := filepath.Abs(s.cfgPath)
+	if err != nil {
+		return "", err
+	}
+	p := filepath.Join(filepath.Dir(cfgAbs), "..", "metro-maker4", "next-app-2",
+		"scripts", "metro-to-portolan.ts")
+	if _, err := os.Stat(p); err != nil {
+		return "", fmt.Errorf("no Subway Builder checkout beside this repo (%s) — set SB_METRO_IMPORTER to metro-to-portolan.ts", p)
+	}
+	return p, nil
+}
+
+// npx is not necessarily on the atlas process's PATH — `make atlas` from a
+// GUI-launched terminal misses the homebrew bin dirs.
+func findNpx() (string, error) {
+	if p, err := exec.LookPath("npx"); err == nil {
+		return p, nil
+	}
+	for _, p := range []string{"/opt/homebrew/bin/npx", "/usr/local/bin/npx"} {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("npx not found — the importer runs via `npx tsx` from the game repo")
+}
+
+var unsafeName = regexp.MustCompile(`[^A-Za-z0-9._ -]+`)
+
+func (s *Server) importMetro(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST", 405)
+		return
+	}
+	script, err := s.importerScript()
+	if err != nil {
+		http.Error(w, err.Error(), 501)
+		return
+	}
+	npx, err := findNpx()
+	if err != nil {
+		http.Error(w, err.Error(), 501)
+		return
+	}
+
+	// Keep the uploaded basename: when a save predates city codes in the
+	// header, the script derives the feed key from the filename.
+	name := unsafeName.ReplaceAllString(filepath.Base(r.URL.Query().Get("name")), "-")
+	if name == "" || name == "." || name == "-" {
+		name = "upload.metro"
+	}
+	tmpDir, err := os.MkdirTemp("", "metro-import-*")
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+	tmp := filepath.Join(tmpDir, name)
+	f, err := os.Create(tmp)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	_, err = io.Copy(f, http.MaxBytesReader(w, r.Body, 512<<20))
+	f.Close()
+	if err != nil {
+		http.Error(w, "upload failed: "+err.Error(), 400)
+		return
+	}
+
+	// One import at a time: the script read-modify-writes portolan.json.
+	s.importMu.Lock()
+	defer s.importMu.Unlock()
+
+	cfgAbs, _ := filepath.Abs(s.cfgPath)
+	repo := filepath.Dir(cfgAbs)
+	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, npx, "tsx", script, tmp, "--repo", repo, "--json")
+	cmd.Dir = filepath.Dir(filepath.Dir(script)) // the game app dir — node_modules lives there
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		// the last stderr line is the script's own message; the lines
+		// above it are npm/tsx noise nobody needs in a toast
+		if lines := strings.Split(msg, "\n"); len(lines) > 1 {
+			msg = strings.TrimSpace(lines[len(lines)-1])
+		}
+		http.Error(w, "import failed: "+msg, 422)
+		return
+	}
+
+	// stdout's last non-empty line is the result object
+	var resLine string
+	for _, l := range strings.Split(stdout.String(), "\n") {
+		if l = strings.TrimSpace(l); l != "" {
+			resLine = l
+		}
+	}
+	var res map[string]any
+	if err := json.Unmarshal([]byte(resLine), &res); err != nil || res["key"] == nil {
+		http.Error(w, "importer returned no result — ran an old script without --json?", 500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(res)
+}

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,16 +1,90 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { Menu, Compass } from 'lucide-vue-next'
 import AppSidebar from './components/AppSidebar.vue'
 import Toaster from './components/ui/Toaster.vue'
-import { refreshFeeds, startRunPoll, stopRunPoll } from './lib/store'
+import { api } from './lib/api'
+import { feed, refreshFeeds, startRunPoll, stopRunPoll } from './lib/store'
+import { toast } from './lib/toast'
+
+// ── .metro drag-and-drop ─────────────────────────────────────────────
+// Drop a Subway Builder save anywhere on the console and it becomes a
+// feed: the server hands it to the game repo's importer (the game's own
+// exportFeed adapter), registers it, and we chart it right away. The
+// listeners live on window so every view is a target — including the map.
+const dragDepth = ref(0)
+const importing = ref(false)
+const router = useRouter()
+
+const hasFiles = (e: DragEvent) => Array.from(e.dataTransfer?.types ?? []).includes('Files')
+const onDragEnter = (e: DragEvent) => {
+  if (hasFiles(e)) {
+    e.preventDefault()
+    dragDepth.value++
+  }
+}
+// continuous preventDefault is what makes the drop event fire at all
+const onDragOver = (e: DragEvent) => hasFiles(e) && e.preventDefault()
+const onDragLeave = (e: DragEvent) => {
+  if (hasFiles(e)) dragDepth.value = Math.max(0, dragDepth.value - 1)
+}
+const onDrop = async (e: DragEvent) => {
+  if (!hasFiles(e)) return
+  e.preventDefault()
+  dragDepth.value = 0
+  const file = Array.from(e.dataTransfer?.files ?? []).find((f) =>
+    f.name.toLowerCase().endsWith('.metro'),
+  )
+  if (!file) {
+    toast({ title: 'Not a .metro save', description: 'Drop a Subway Builder save file.', variant: 'warning' })
+    return
+  }
+  if (importing.value) return
+  importing.value = true
+  try {
+    const res = await api.importMetro(file)
+    await refreshFeeds()
+    feed.value = res.key
+    try {
+      await api.run(res.key, 'chart')
+      toast({
+        title: `Imported ${res.name}`,
+        description: `Charting ${res.features} track features — the map updates when the run finishes.`,
+        variant: 'success',
+      })
+      router.push('/build')
+    } catch {
+      // 409: another run holds the single job slot — the feed is in, so
+      // this is a detour, not a failure
+      toast({
+        title: `Imported ${res.name}`,
+        description: 'A run is already in progress — chart it from the Build page when it finishes.',
+        variant: 'warning',
+      })
+    }
+  } catch (err: any) {
+    toast({ title: 'Import failed', description: err.message, variant: 'error', duration: 12000 })
+  } finally {
+    importing.value = false
+  }
+}
 
 onMounted(() => {
   refreshFeeds()
   startRunPoll()
+  window.addEventListener('dragenter', onDragEnter)
+  window.addEventListener('dragover', onDragOver)
+  window.addEventListener('dragleave', onDragLeave)
+  window.addEventListener('drop', onDrop)
 })
-onUnmounted(stopRunPoll)
+onUnmounted(() => {
+  stopRunPoll()
+  window.removeEventListener('dragenter', onDragEnter)
+  window.removeEventListener('dragover', onDragOver)
+  window.removeEventListener('dragleave', onDragLeave)
+  window.removeEventListener('drop', onDrop)
+})
 
 // On a phone the sidebar is a drawer; picking a destination is what closes
 // it, so navigation itself dismisses — no close button to hunt for.
@@ -52,6 +126,21 @@ watch(() => route.fullPath, () => (sidebarOpen.value = false))
       ]"
     />
     <main class="min-h-0 flex-1 overflow-y-auto app-grid-bg"><RouterView /></main>
+
+    <!-- pointer-events-none: the drop must land on window, not the veil -->
+    <div
+      v-if="dragDepth > 0 || importing"
+      class="pointer-events-none fixed inset-0 z-[70] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+    >
+      <div class="rounded-xl border-2 border-dashed border-primary bg-card px-10 py-8 text-center shadow-2xl">
+        <div class="text-lg font-semibold">
+          {{ importing ? 'Importing save…' : 'Drop the .metro save' }}
+        </div>
+        <div class="mt-1 text-sm text-muted-foreground">
+          {{ importing ? 'Running the game exporter, then charting' : 'It becomes a feed and charts automatically' }}
+        </div>
+      </div>
+    </div>
   </div>
   <Toaster />
 </template>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -90,6 +90,15 @@ export interface ScenariosResp {
   grid?: string[][]
 }
 
+/** /api/import/metro result — the feed the save became. */
+export interface MetroImport {
+  key: string
+  name: string
+  city?: string | null
+  tables: number
+  features: number
+}
+
 export interface RunStatus {
   running: boolean
   done: boolean
@@ -181,6 +190,15 @@ export const api = {
     }
     return (await r.json()) as TileJSON
   },
+
+  /** POST a Subway Builder .metro save; the server converts it via the
+   *  game repo's importer and registers the feed. Slow (seconds) — the
+   *  script boots tsx and runs the game's exportFeed. */
+  importMetro: (file: File) =>
+    req<MetroImport>(`/api/import/metro?name=${encodeURIComponent(file.name)}`, {
+      method: 'POST',
+      body: file,
+    }),
 
   run: (feed: string, cmd: 'chart' | 'sound', scenario?: string) =>
     req<null>(


### PR DESCRIPTION
## What

Drop a `.metro` Subway Builder save anywhere on the console (any view, including the map) and it becomes a feed: imported, selected, charted, and the view jumps to Build to watch the run.

## How

- **`POST /api/import/metro`** (`internal/atlas/importmetro.go`): saves the upload to a temp dir and shells out to the game repo's importer (`scripts/metro-to-portolan.ts --json`). The converter deliberately stays in the game repo — a `.metro` is the game's container, and the game's own `exportFeed` adapter is the only faithful serializer (it's the exact GTFS + rail + curation doc the game hands the engine at runtime). The script writes `data/sb/<key>/` + `style/<key>.json` into this checkout and registers the feed in `portolan.json`; the existing mtime hot-reload picks it up with no restart.
- **Game checkout discovery**: `../metro-maker4/next-app-2` beside this repo (the mirror image of the game's `../../portolan` default), or `SB_METRO_IMPORTER`. Without one the endpoint answers 501 with instructions, so a checkout without the game repo just doesn't grow the feature.
- **Console** (`web/src/App.vue`): window-level drag listeners with a depth-counted overlay veil (`pointer-events-none` so the drop lands on window). On drop: import → `refreshFeeds()` → select the new feed → `run chart` → route to Build. If another run holds the single job slot, the 409 downgrades to a "chart it from Build" toast — the feed is in either way.
- Imports serialize on their own mutex (the script read-modify-writes `portolan.json`); `npx` is resolved past PATHs that miss the homebrew bin dirs.

## Tested

- Endpoint round-trip with a real save: upload → `{"key":"sb-chi","tables":6,"features":2328}` → feed listed immediately → `chart` run completes (`fair: 244 segments`, 210 stations, 1255 caterpillar bullets).
- `go build ./...`, `vue-tsc --noEmit`, and a `vite build` all clean.

Re-running with the same save overwrites the feed in place, so "refresh the atlas copy" is just dropping the file again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)