### PR TITLE
atlas: uploaded saves are their own group, named and deletable

### DIFF
--- a/internal/atlas/atlas.go
+++ b/internal/atlas/atlas.go
@@ -371,6 +371,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/routes", s.routesAPI)
 	mux.HandleFunc("/console/", s.console)
 	mux.HandleFunc("/api/import/metro", s.importMetro)
+	mux.HandleFunc("/api/import/metro/delete", s.deleteImport)
 	mux.HandleFunc("/api/run", s.run)
 	mux.HandleFunc("/api/run/status", s.runStatus)
 	mux.HandleFunc("/api/score", s.score)

--- a/internal/atlas/console.go
+++ b/internal/atlas/console.go
@@ -102,15 +102,18 @@ type cityJSON struct {
 	// Members marks a GROUP build — several feeds charted as one graph so
 	// their routes bundle on shared track. The console lists these apart
 	// from ordinary feeds; they are metro areas, not agencies.
-	Members []string    `json:"members,omitempty"`
-	Status  *cityStatus `json:"status,omitempty"`
+	Members []string `json:"members,omitempty"`
+	// Imported marks an uploaded .metro save: the console groups these
+	// apart from the real-world roster and offers to delete them.
+	Imported bool        `json:"imported,omitempty"`
+	Status   *cityStatus `json:"status,omitempty"`
 }
 
 func (s *Server) cityJSONOf(id string, fc FeedCfg, dirs dirIndex) cityJSON {
 	c := cityJSON{
 		ID: id, Name: fc.Name, GTFS: fc.GTFS, Rail: fc.Rail, Streets: fc.Streets,
 		Stops: fc.Stops, Out: fc.Out, Network: fc.Network, BBox: fc.BBox,
-		Members: fc.Members,
+		Members: fc.Members, Imported: fc.Imported,
 	}
 	st := &cityStatus{Rail: statOf(fc.Rail)}
 	for _, p := range strings.Split(fc.GTFS, ",") {

--- a/internal/atlas/importmetro.go
+++ b/internal/atlas/importmetro.go
@@ -151,3 +151,105 @@ func (s *Server) importMetro(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(res)
 }
+
+// deleteImport removes an uploaded save: the portolan.json entry and every
+// file the importer wrote for it. The exact inverse of the import above,
+// and deliberately no more than that — a build output or a sketch drawn
+// over the save is the user's work, so those go too only because the feed
+// they belong to is going.
+//
+// GUARDED to entries the importer made (FeedCfg.Imported). The console
+// only offers delete on those, but the endpoint cannot trust that: this is
+// the one route that removes a config entry and files from the checkout,
+// and a mistyped key must not be able to unregister the MTA. The marker is
+// set by the importer alone, so a curated feed can never match.
+func (s *Server) deleteImport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost && r.Method != http.MethodDelete {
+		http.Error(w, "POST or DELETE", 405)
+		return
+	}
+	key := strings.TrimSpace(r.URL.Query().Get("feed"))
+	if key == "" {
+		http.Error(w, "missing ?feed=", 400)
+		return
+	}
+	fc, ok := s.config().Feeds[key]
+	if !ok {
+		http.Error(w, "no such feed: "+key, 404)
+		return
+	}
+	if !fc.Imported {
+		http.Error(w, key+" is a curated feed, not an uploaded save — refusing to delete", 403)
+		return
+	}
+
+	// Serialize with import: both read-modify-write portolan.json, and the
+	// file sweep below must not race a re-import of the same key.
+	s.importMu.Lock()
+	defer s.importMu.Unlock()
+
+	if err := s.editConfig(func(doc map[string]any) error {
+		feeds, _ := doc["feeds"].(map[string]any)
+		if feeds == nil {
+			return fmt.Errorf("config has no feeds map")
+		}
+		delete(feeds, key)
+		return nil
+	}); err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+	// Paths come from the ENTRY, not from a rebuilt guess at what the
+	// importer would have written: a hand-edited entry pointing somewhere
+	// else must take its own files, and only its own.
+	cfgAbs, _ := filepath.Abs(s.cfgPath)
+	repo := filepath.Dir(cfgAbs)
+	inRepo := func(p string) (string, bool) {
+		if p == "" {
+			return "", false
+		}
+		abs := p
+		if !filepath.IsAbs(abs) {
+			abs = filepath.Join(repo, p)
+		}
+		abs = filepath.Clean(abs)
+		// never escape the checkout, whatever the entry says
+		rel, err := filepath.Rel(repo, abs)
+		if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+			return "", false
+		}
+		return abs, true
+	}
+	var removed []string
+	drop := func(p string) {
+		abs, ok := inRepo(p)
+		if !ok {
+			return
+		}
+		if err := os.RemoveAll(abs); err == nil {
+			if rel, err := filepath.Rel(repo, abs); err == nil {
+				removed = append(removed, rel)
+			}
+		}
+	}
+	// the importer writes data/sb/<key>/{gtfs,rail.geojson}; drop the feed
+	// DIRECTORY rather than the two paths, so nothing is orphaned
+	if abs, ok := inRepo(fc.GTFS); ok {
+		drop(filepath.Dir(abs))
+	}
+	drop(fc.Rail)
+	drop(filepath.Join("style", key+".json"))
+	drop(fc.Network)
+	// build outputs: <out> plus the sidecars chart writes beside it
+	if abs, ok := inRepo(fc.Out); ok {
+		matches, _ := filepath.Glob(abs + "*")
+		for _, m := range matches {
+			drop(m)
+		}
+	}
+	drop(filepath.Join("build", "tiles", key))
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"key": key, "removed": removed})
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -45,6 +45,13 @@ type FeedCfg struct {
 	// Onestop: the feed's Transitland onestop id — how sync asks whether
 	// the feed changed upstream. Empty means sync skips the feed.
 	Onestop string `json:"onestop,omitempty"`
+	// Imported marks a feed the console MADE, not one a human curated:
+	// a Subway Builder .metro save uploaded through /api/import/metro.
+	// Its inputs live under data/sb/<key>/ and were written by the
+	// importer, so the console may list it apart from the real-world
+	// roster and may DELETE it — neither of which is safe to infer from
+	// a key prefix, which a hand-written entry could also carry.
+	Imported bool `json:"imported,omitempty"`
 }
 
 // PrimaryGTFS: the first feed of the comma list — scenarios and mtime

--- a/web/src/components/FeedPicker.vue
+++ b/web/src/components/FeedPicker.vue
@@ -8,15 +8,21 @@
 // Global is a context, not a feed. Metro areas are group builds — several
 // feeds charted as one graph so their routes bundle on shared track — and
 // they replace their members in the world map, so they belong above the
-// agencies they absorb, not filed alphabetically among them.
+// agencies they absorb, not filed alphabetically among them. Uploaded
+// Subway Builder saves are not agencies at all: they are the player's own
+// networks, they arrive and go on the user's schedule rather than the
+// roster's, and they are the only entries here that can be DELETED — so
+// they get their own heading at the top rather than being scattered
+// through 1,499 real operators that happen to sort near them.
 import { computed, ref, watch } from 'vue'
 import {
   ComboboxRoot, ComboboxAnchor, ComboboxTrigger, ComboboxInput, ComboboxPortal,
   ComboboxContent, ComboboxViewport, ComboboxGroup, ComboboxLabel, ComboboxItem,
   ComboboxItemIndicator, ComboboxEmpty,
 } from 'reka-ui'
-import { ChevronDown, Check, Search, Globe, Building2 } from 'lucide-vue-next'
-import { feeds, feed, GLOBAL } from '@/lib/store'
+import { ChevronDown, Check, Search, Globe, Building2, Gamepad2, Trash2, Loader2 } from 'lucide-vue-next'
+import { feeds, feed, GLOBAL, refreshFeeds } from '@/lib/store'
+import { api } from '@/lib/api'
 
 // Rendering every match is what made the old list janky; past this many
 // the answer is a better search term, not a longer list.
@@ -31,14 +37,17 @@ const query = ref('')
 const blank = () => ''
 watch(open, () => { query.value = '' })
 
-const metros = computed(() => feeds.value.filter((f) => f.members?.length))
-const agencies = computed(() => feeds.value.filter((f) => !f.members?.length))
+const saves = computed(() => feeds.value.filter((f) => f.imported))
+const metros = computed(() => feeds.value.filter((f) => !f.imported && f.members?.length))
+const agencies = computed(() => feeds.value.filter((f) => !f.imported && !f.members?.length))
 
 const label = (f: { id: string; name?: string }) => f.name || f.id
 const hit = (f: { id: string; name?: string }, q: string) =>
   label(f).toLowerCase().includes(q) || f.id.toLowerCase().includes(q)
 
 const q = computed(() => query.value.trim().toLowerCase())
+const shownSaves = computed(() =>
+  q.value ? saves.value.filter((f) => hit(f, q.value)) : saves.value)
 const shownMetros = computed(() =>
   q.value ? metros.value.filter((f) => hit(f, q.value)) : metros.value)
 const matched = computed(() =>
@@ -47,11 +56,35 @@ const shownAgencies = computed(() => matched.value.slice(0, CAP))
 const hidden = computed(() => matched.value.length - shownAgencies.value.length)
 const showGlobal = computed(() => !q.value || 'global'.includes(q.value))
 const empty = computed(() =>
-  !showGlobal.value && !shownMetros.value.length && !shownAgencies.value.length)
+  !showGlobal.value && !shownSaves.value.length && !shownMetros.value.length &&
+  !shownAgencies.value.length)
 
 const current = computed(() => feeds.value.find((f) => f.id === feed.value))
 const currentLabel = computed(() =>
   feed.value === GLOBAL ? 'Global' : current.value ? label(current.value) : 'Pick a feed…')
+
+// Deleting a save removes its inputs, its build and any sketch drawn over
+// it — work that cannot be recovered from the checkout, only by uploading
+// the .metro again — so it asks first. The picker stays OPEN through the
+// round trip: closing it on click would hide the row that is mid-delete.
+const deleting = ref('')
+async function removeSave(f: { id: string; name?: string }, ev: Event) {
+  ev.preventDefault()
+  ev.stopPropagation()
+  if (deleting.value) return
+  if (!confirm(`Delete “${label(f)}”?\n\nRemoves the imported feed, its build and any sketch drawn over it. Re-upload the .metro to get it back.`)) return
+  deleting.value = f.id
+  try {
+    await api.deleteMetroImport(f.id)
+    // If the open feed was the one deleted, refreshFeeds falls back to the
+    // first entry on its own — it already handles a stale persisted id.
+    await refreshFeeds()
+  } catch (e) {
+    alert(`Could not delete ${label(f)}: ${e instanceof Error ? e.message : String(e)}`)
+  } finally {
+    deleting.value = ''
+  }
+}
 
 const itemClass =
   'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground'
@@ -111,6 +144,35 @@ const labelClass =
             <Globe class="mr-2 size-4 shrink-0 text-muted-foreground" />
             Global
           </ComboboxItem>
+
+          <ComboboxGroup v-if="shownSaves.length">
+            <ComboboxLabel :class="labelClass">Subway Builder saves</ComboboxLabel>
+            <ComboboxItem
+              v-for="f in shownSaves"
+              :key="f.id"
+              :value="f.id"
+              :class="[itemClass, 'pr-1']"
+            >
+              <span class="absolute left-2 flex size-4 items-center justify-center">
+                <ComboboxItemIndicator><Check class="size-4" /></ComboboxItemIndicator>
+              </span>
+              <Gamepad2 class="mr-2 size-4 shrink-0 text-muted-foreground" />
+              <span class="truncate">{{ label(f) }}</span>
+              <button
+                type="button"
+                :disabled="!!deleting"
+                :aria-label="`Delete ${label(f)}`"
+                :title="`Delete ${label(f)}`"
+                class="ml-auto flex size-6 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+                @click="removeSave(f, $event)"
+                @pointerdown.stop.prevent
+                @keydown.enter.stop
+              >
+                <Loader2 v-if="deleting === f.id" class="size-3.5 animate-spin" />
+                <Trash2 v-else class="size-3.5" />
+              </button>
+            </ComboboxItem>
+          </ComboboxGroup>
 
           <ComboboxGroup v-if="shownMetros.length">
             <ComboboxLabel :class="labelClass">Metro areas</ComboboxLabel>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -64,6 +64,10 @@ export interface Feed {
   /** a GROUP build: the feed keys charted together as one graph, so their
    *  routes bundle on shared track. Present only on metro-area entries. */
   members?: string[]
+  /** an uploaded Subway Builder .metro save, registered by the importer
+   *  rather than curated by hand. The picker files these under their own
+   *  heading and offers to delete them; nothing else may be deleted. */
+  imported?: boolean
   /** server-computed: which inputs actually exist on disk */
   status?: FeedStatus
 }
@@ -199,6 +203,14 @@ export const api = {
       method: 'POST',
       body: file,
     }),
+
+  /** Delete an uploaded save: its portolan.json entry and every file the
+   *  importer wrote for it. Server-side guarded to `imported` feeds. */
+  deleteMetroImport: (feed: string) =>
+    req<{ key: string; removed: string[] }>(
+      `/api/import/metro/delete?feed=${encodeURIComponent(feed)}`,
+      { method: 'POST' },
+    ),
 
   run: (feed: string, cmd: 'chart' | 'sound', scenario?: string) =>
     req<null>(


### PR DESCRIPTION
Three things the `.metro` upload was missing once there was more than one save in the picker.

- Uploaded saves get their own heading above the roster. They were falling into the 1,499-agency list, sorted among real operators — but they are the player's own networks, they come and go on the user's schedule, and they are the only entries that can be deleted
- The grouping signal is an explicit `imported` marker on the config entry, set by the importer, not the `sb-` key prefix. A prefix is guessable, and this same flag authorizes deletion — a curated feed can never carry it
- Feeds are now named by the uploaded FILENAME. The importer keyed by city code and named from the save header, and every Subway Builder save is called "Current Game" — so two uploads listed as two identical rows. Worse than the duplicate label: two saves of one city shared a key, and the second import silently overwrote the first's inputs
- New `POST /api/import/metro/delete?feed=<key>` removes the config entry and every file the importer wrote — feed directory, style file, sketch, build output with its chart sidecars, tile pyramid. Paths come from the entry rather than a guess, each clamped inside the checkout
- Guarded on `imported` server-side, not just hidden in the UI: this is the one route that deletes files from the checkout

Measured on the running console. Uploading two saves lists two rows under SUBWAY BUILDER SAVES with their filenames. Deleting one removed 13 artifacts and left the other save and all 1,520 curated feeds untouched. Deleting `mta-subway` is refused with 403; an unknown key gets 404. Re-uploading the same filename refreshes in place.

The atlas half is inert without the matching game-side importer change (`imported: true` + filename naming), which lives in metro-maker4. The endpoint already reports clearly when that script is missing entirely.