### PR TITLE
Match stops to the station, not the rails

### DIFF
--- a/internal/pipeline/osmstops.go
+++ b/internal/pipeline/osmstops.go
@@ -47,7 +47,31 @@ type OSMStop struct {
 	Name    string
 	LL      geo.LL
 	Classes map[string]bool // portolan class names this stop can serve
+	// Station: this object is the station as a PLACE
+	// (public_transport=station, railway=station, amenity=ferry_terminal),
+	// rather than a stop_position — a point on the track where a train
+	// halts. Both carry the station's name and sit metres apart, so
+	// distance cannot tell them apart, but only one of them is somewhere a
+	// rider can be sent.
+	Station bool
 	toks    []string
+}
+
+// osmStopIsStation reports whether an OSM object is the station itself
+// rather than a stopping point on the rails inside it.
+func osmStopIsStation(p map[string]any) bool {
+	s := func(k string) string {
+		v, _ := p[k].(string)
+		return strings.ToLower(strings.TrimSpace(v))
+	}
+	switch s("public_transport") {
+	case "station":
+		return true
+	case "stop_position", "platform":
+		return false
+	}
+	return s("railway") == "station" || s("railway") == "halt" ||
+		s("amenity") == "ferry_terminal" || s("aerialway") == "station"
 }
 
 // osmStopClasses reads the class of an OSM stop from its tags. A stop can
@@ -152,6 +176,7 @@ func LoadOSMStops(path string) ([]OSMStop, error) {
 			ID: f.ID, Name: name,
 			LL:      geo.LL{Lon: f.Geometry.Coordinates[0], Lat: f.Geometry.Coordinates[1]},
 			Classes: osmStopClasses(f.Props),
+			Station: osmStopIsStation(f.Props),
 			toks:    nameTokens(name),
 		})
 	}
@@ -380,6 +405,11 @@ func needSim(d float64) float64 {
 	return t * osmSimAtRange
 }
 
+// osmStationBonus outranks roughly 20 m of distance: enough that a station
+// node beats a stop_position across the platform, not enough to reach past
+// a genuinely nearer station.
+const osmStationBonus = 0.13
+
 // MatchOSMStops pairs stations with OSM stops and returns the accepted
 // matches, best-first. It does not mutate the stations — the caller
 // decides whether a match renames anything (ApplyOSMStopMatches).
@@ -445,6 +475,18 @@ func MatchOSMStops(sts []Station, stops []OSMStop, frame geo.Frame) []StopMatch 
 			// proximity dominates the ranking too; the name only orders
 			// candidates that are similarly close
 			score := 0.65*(1-d/osmMatchRadiusM) + 0.35*sim
+			// ...but a station outranks a stopping point that is merely
+			// nearer. Both carry the station's name and sit metres apart, so
+			// without this the winner is whichever the feed's coordinate
+			// happened to land beside: Clark St matched its station node and
+			// Jay St–MetroTech matched one of its six stop_positions, and the
+			// panel called them different kinds of place. Only the station is
+			// somewhere a rider can be sent. A bonus rather than a filter —
+			// plenty of stations are mapped with no station node at all, and
+			// a stop_position is a better answer there than none.
+			if stops[oi].Station {
+				score += osmStationBonus
+			}
 			cands = append(cands, cand{si, oi, score, d, sim})
 		}
 	}

--- a/internal/pipeline/osmstops_test.go
+++ b/internal/pipeline/osmstops_test.go
@@ -1,0 +1,48 @@
+package pipeline
+
+import "testing"
+
+// Both kinds of OSM object carry the station's name and sit metres apart:
+// public_transport=station is the station as a place, stop_position is a
+// point on the track where a train halts. Distance alone cannot tell them
+// apart, and picking the wrong one sends a rider to a spot on the rails —
+// Jay St–MetroTech has six stop_positions and two station nodes, and matched
+// a stop_position while Clark St matched its station.
+func TestOSMStopIsStation(t *testing.T) {
+	cases := []struct {
+		name  string
+		props map[string]any
+		want  bool
+	}{
+		{"public_transport=station", map[string]any{"public_transport": "station", "railway": "station"}, true},
+		{"stop_position", map[string]any{"public_transport": "stop_position", "railway": "stop"}, false},
+		{"platform", map[string]any{"public_transport": "platform"}, false},
+		{"bare railway=station", map[string]any{"railway": "station"}, true},
+		{"ferry terminal", map[string]any{"amenity": "ferry_terminal"}, true},
+		{"aerialway station", map[string]any{"aerialway": "station"}, true},
+		{"nothing useful", map[string]any{"highway": "bus_stop"}, false},
+	}
+	for _, c := range cases {
+		if got := osmStopIsStation(c.props); got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// The bonus has to beat a stop_position that is nearer, without reaching
+// past a station that is genuinely closer.
+func TestStationBonusOutranksACloserStopPosition(t *testing.T) {
+	// A stop_position 10 m away vs a station node 25 m away.
+	near := 0.65*(1-10.0/osmMatchRadiusM) + 0.35*1.0
+	far := 0.65*(1-25.0/osmMatchRadiusM) + 0.35*1.0 + osmStationBonus
+	if far <= near {
+		t.Errorf("station at 25m (%.4f) should outrank stop_position at 10m (%.4f)", far, near)
+	}
+
+	// But a station 10 m away still beats one 200 m away.
+	close := 0.65*(1-10.0/osmMatchRadiusM) + 0.35*1.0 + osmStationBonus
+	distant := 0.65*(1-200.0/osmMatchRadiusM) + 0.35*1.0 + osmStationBonus
+	if distant >= close {
+		t.Errorf("a distant station must not outrank a near one")
+	}
+}


### PR DESCRIPTION
Some subway stations in Parchment are labelled "Subway Station" and others
"Subway Stopping Location". The label is derived correctly from the matched
OSM object's tags; the bug is which object gets matched.

`MatchOSMStops` scored candidates as `0.65 * proximity + 0.35 * name
similarity`, with no term for what kind of object a candidate was. A
`stop_position` — a point on the track where a train halts — carries the
station's name and sits metres from the station node, so the winner was
whichever the feed's coordinate happened to land beside:

- Clark St — 1 station node, 2 stop_positions — matched the station.
- Jay St–MetroTech — 2 station nodes, 6 stop_positions — matched a stop_position.

Same kind of place, two different answers.

## What changed

Assignment now runs in two passes. Station-type objects
(`public_transport=station`, `railway=station|halt`, `amenity=ferry_terminal`,
`aerialway=station`) are assigned first; only the feed stations left unmatched
fall back to a stop_position or platform.

A fallback rather than a filter, deliberately: plenty of stations are mapped
with no station node at all, and a stop_position is a better answer there than
none. The second pass stays gated on radius, class and name similarity like
any other candidate, so it cannot reach further than the first.

Each pass still assigns greedily by score, so two adjacent stations each take
their own station node rather than one stranding the other on a stopping point.

## Tests

Four cases in `internal/pipeline/osmstops_test.go`: the tag classification, a
station winning from further away than a stop_position, a stop_position still
being used where no station is mapped, and two neighbouring stations each
taking their own node. The three behavioural tests fail against the old
single-pass assignment — verified by reverting it.

Full suite green, including the `internal/stages` golden tests, so no drawn
geometry moves.

## Note

This does not fix the labels on its own — the pyramid has to be rebuilt with
it before anything changes downstream.