### PR TITLE
Make the global build cover each feed's own data

### DIFF
--- a/internal/sync/assemble.go
+++ b/internal/sync/assemble.go
@@ -15,6 +15,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/alexwohlbruck/portolan/internal/registry"
@@ -288,6 +289,126 @@ func mergeFC(dst string, srcs []string) (int, error) {
 	return len(feats), nil
 }
 
+// featureBBox returns a feature geometry's own extent, or ok=false for a
+// geometry this walk does not understand. Shared with railCovers so the
+// coverage test and the clip agree on what a feature occupies.
+func featureBBox(geomType string, coords json.RawMessage) (w, s, e, n float64, ok bool) {
+	w, s = math.Inf(1), math.Inf(1)
+	e, n = math.Inf(-1), math.Inf(-1)
+	take := func(c [2]float64) {
+		w, e = math.Min(w, c[0]), math.Max(e, c[0])
+		s, n = math.Min(s, c[1]), math.Max(n, c[1])
+	}
+	switch geomType {
+	case "Point":
+		var p [2]float64
+		if json.Unmarshal(coords, &p) != nil {
+			return 0, 0, 0, 0, false
+		}
+		take(p)
+	case "LineString", "MultiPoint":
+		var pts [][2]float64
+		if json.Unmarshal(coords, &pts) != nil {
+			return 0, 0, 0, 0, false
+		}
+		for _, c := range pts {
+			take(c)
+		}
+	case "Polygon", "MultiLineString":
+		var rings [][][2]float64
+		if json.Unmarshal(coords, &rings) != nil {
+			return 0, 0, 0, 0, false
+		}
+		for _, r := range rings {
+			for _, c := range r {
+				take(c)
+			}
+		}
+	case "MultiPolygon":
+		var polys [][][][2]float64
+		if json.Unmarshal(coords, &polys) != nil {
+			return 0, 0, 0, 0, false
+		}
+		for _, poly := range polys {
+			for _, r := range poly {
+				for _, c := range r {
+					take(c)
+				}
+			}
+		}
+	default:
+		return 0, 0, 0, 0, false
+	}
+	return w, s, e, n, !math.IsInf(w, 1)
+}
+
+// clipFC is mergeFC with a window: only features whose own extent meets the
+// bbox are kept. Clipping rather than merging matters for memory — the
+// Northeast Corridor's rail extract is 166 MB, and a feed that merged the
+// whole thing to reach its own corner would chart as heavily as the whole
+// corridor does. A feature straddling the edge is kept whole; the chart
+// clips geometry itself.
+func clipFC(dst string, srcs []string, bbox []float64) (int, error) {
+	if len(bbox) != 4 {
+		return mergeFC(dst, srcs)
+	}
+	type feature struct {
+		ID    any             `json:"id,omitempty"`
+		Type  string          `json:"type"`
+		Props json.RawMessage `json:"properties,omitempty"`
+		Geom  json.RawMessage `json:"geometry"`
+	}
+	seen := map[string]bool{}
+	var feats []feature
+	for _, src := range srcs {
+		raw, err := os.ReadFile(src)
+		if err != nil {
+			return 0, err
+		}
+		var fc struct {
+			Features []struct {
+				feature
+				Geometry struct {
+					Type        string          `json:"type"`
+					Coordinates json.RawMessage `json:"coordinates"`
+				} `json:"geometry"`
+			} `json:"features"`
+		}
+		if err := json.Unmarshal(raw, &fc); err != nil {
+			return 0, fmt.Errorf("%s: %w", src, err)
+		}
+		for _, f := range fc.Features {
+			w, s2, e, n, ok := featureBBox(f.Geometry.Type, f.Geometry.Coordinates)
+			if !ok || w > bbox[2] || e < bbox[0] || s2 > bbox[3] || n < bbox[1] {
+				continue
+			}
+			if f.ID != nil {
+				id := fmt.Sprint(f.ID)
+				if seen[id] {
+					continue
+				}
+				seen[id] = true
+			}
+			feats = append(feats, f.feature)
+		}
+	}
+	out := struct {
+		Type     string    `json:"type"`
+		Features []feature `json:"features"`
+	}{Type: "FeatureCollection", Features: feats}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return 0, err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return 0, err
+	}
+	if err := atomicWrite(dst, append(raw, '\n')); err != nil {
+		return 0, err
+	}
+	return len(feats), nil
+}
+
 // ------------------------------------------------------------ preflight
 
 // groupPreflight is groupbuild.sh's per-group preparation, minus the
@@ -297,6 +418,63 @@ func mergeFC(dst string, srcs []string) (int, error) {
 // merges the same way; streets_from merges into streets (mergefc, as the
 // shell does). Merged extracts overlap where windows meet — mergeFC's
 // id-dedup is what keeps the shared way single.
+// feedPreflight prepares a PLAIN feed the way groupPreflight prepares a
+// group: if its rail extract does not cover its window, cut one that does.
+// A group merges from its members; a lone feed has none, so it borrows from
+// any feed in the registry whose extract already covers the window — the
+// regional group's, in practice — and clips that to its own box.
+//
+// This exists because a window and an extract have to agree. Widening
+// Metro-North to the railroad it actually runs is useless while its extract
+// still stops at the New York City line, and sync must never call Overpass.
+func feedPreflight(cfg registry.Config, key, buildDir string,
+	logf func(string, ...any)) error {
+	fc := cfg.Feeds[key]
+	if fc.Rail == "" || len(fc.BBox) != 4 || railCovers(fc.Rail, fc.BBox) {
+		return nil
+	}
+	// Widest first: one source that covers the whole window beats several
+	// that each cover a corner.
+	type cand struct {
+		path string
+		area float64
+	}
+	var cands []cand
+	seen := map[string]bool{}
+	for _, other := range cfg.Feeds {
+		p := other.Rail
+		if p == "" || p == fc.Rail || seen[p] {
+			continue
+		}
+		if st, err := os.Stat(p); err != nil || st.Size() == 0 {
+			continue
+		}
+		if !railCovers(p, fc.BBox) {
+			continue
+		}
+		seen[p] = true
+		a := 0.0
+		if len(other.BBox) == 4 {
+			a = (other.BBox[2] - other.BBox[0]) * (other.BBox[3] - other.BBox[1])
+		}
+		cands = append(cands, cand{p, a})
+	}
+	if len(cands) == 0 {
+		return fmt.Errorf("%s: rail extract at %s does not cover the window and no other extract covers it either", key, fc.Rail)
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i].area > cands[j].area })
+	dst := fc.Rail
+	if !strings.HasPrefix(dst, "build/") {
+		dst = filepath.Join(buildDir, key+"-rail.geojson")
+	}
+	n, err := clipFC(dst, []string{cands[0].path}, fc.BBox)
+	if err != nil {
+		return fmt.Errorf("%s: clipping rail extract: %w", key, err)
+	}
+	logf("%s: cut a rail extract to its window from %s (%d ways) — sync never calls Overpass", key, cands[0].path, n)
+	return nil
+}
+
 func groupPreflight(cfg registry.Config, key, buildDir string,
 	logf func(string, ...any)) error {
 	fc := cfg.Feeds[key]

--- a/internal/sync/plan.go
+++ b/internal/sync/plan.go
@@ -34,6 +34,11 @@ type Plan struct {
 	// changed, or a group window they cede moved under them.
 	Overlays []string
 
+	// Widened: feeds whose window was grown to cover their own shapes. A
+	// window smaller than the railroad clips it away without an error, so
+	// the run says which feeds it corrected.
+	Widened []string
+
 	RegistryChanged bool
 	// Registry: the rewritten portolan.json payload (exactly what
 	// groups.py --write would have produced), nil when nothing moved.
@@ -193,6 +198,10 @@ func BuildPlan(o PlanOpts) (*Plan, error) {
 	before := o.Doc
 	after := o.Doc.Clone()
 	kept := RewriteGroups(after, scoped, scope)
+	// A feed's window is also its shape clip, so one smaller than the feed's
+	// own railroad truncates the map silently. Widen before the entries are
+	// diffed, so a widened feed is dirty and rebuilds.
+	widened := WidenFeedWindows(after, der, scope)
 
 	beforeFeeds := feedsObj(before)
 	afterFeeds := feedsObj(after)
@@ -202,7 +211,7 @@ func BuildPlan(o PlanOpts) (*Plan, error) {
 		}
 		return nil
 	}
-	plan := &Plan{Changed: changed, Measured: der.Measured, Derivation: der}
+	plan := &Plan{Changed: changed, Measured: der.Measured, Derivation: der, Widened: widened}
 	keptSet := map[string]bool{}
 	groupInputs := map[string][]string{} // key → member+overlay feeds (kept is 1:1 with scoped.Groups)
 	for i, k := range kept {

--- a/internal/sync/rewrite.go
+++ b/internal/sync/rewrite.go
@@ -6,6 +6,8 @@ package sync
 // result is byte-comparable with a groups.py --write of the same data.
 
 import (
+	"encoding/json"
+	"math"
 	"sort"
 	"strings"
 )
@@ -15,6 +17,96 @@ import (
 // fragment that is 100% gap would fail the whole document. Members are
 // still guarded by tools/groupverify.py, on ink rather than this gate.
 const chartArgsGroup = "--set match_gap_cost=150 --allow-unmatched"
+
+// WidenFeedWindows makes every measured feed's window cover the feed's own
+// data. A feed's bbox is the Overpass window AND the shape clip, so a window
+// smaller than the railroad silently truncates the map: Metro-North carried
+// the subway's [-74.26,40.49,-73.7,40.92] — authored when portolan drew only
+// New York City — and came out with 25 of its 114 stations, everything past
+// Yonkers clipped away with no error. Groups already take their window from
+// measured data (see RewriteGroups); nothing did the same for a plain feed,
+// so a hand-authored window stayed wrong forever.
+//
+// Widening only ever grows a window, and only to what the feed's own shapes
+// occupy plus the margin groups use. A feed whose authored window is already
+// big enough is untouched, so a deliberately generous window survives.
+//
+// Returns the keys widened, in registry order, for the caller to log.
+func WidenFeedWindows(doc *Obj, der *Derivation, scope map[string]bool) []string {
+	feeds := feedsObj(doc)
+	if feeds == nil || der == nil {
+		return nil
+	}
+	var widened []string
+	for _, k := range feeds.Keys() {
+		if scope != nil && !scope[k] {
+			continue
+		}
+		ext, ok := der.Extent[k]
+		if !ok {
+			continue // not measured this run — no data to judge the window by
+		}
+		v, _ := feeds.Get(k)
+		entry, ok := v.(*Obj)
+		if !ok {
+			continue
+		}
+		bv, _ := entry.Get("bbox")
+		arr, _ := bv.([]any)
+		if len(arr) != 4 {
+			continue // no authored window: the chart uses the shapes as-is
+		}
+		cur := make([]float64, 4)
+		for i, a := range arr {
+			f, ok := toFloat(a)
+			if !ok {
+				cur = nil
+				break
+			}
+			cur[i] = f
+		}
+		if cur == nil {
+			continue
+		}
+		// Only a window that genuinely fails to contain the railroad is
+		// corrected. Judging containment WITHOUT the margin matters: adding
+		// slack first would nudge nearly every feed in the registry by a
+		// hair, and each nudge is a rebuild.
+		if cur[0] <= ext[0] && cur[1] <= ext[1] && cur[2] >= ext[2] && cur[3] >= ext[3] {
+			continue
+		}
+		want := []float64{
+			round4(math.Min(cur[0], ext[0]-marginDeg)),
+			round4(math.Min(cur[1], ext[1]-marginDeg)),
+			round4(math.Max(cur[2], ext[2]+marginDeg)),
+			round4(math.Max(cur[3], ext[3]+marginDeg)),
+		}
+		entry.Set("bbox", []any{want[0], want[1], want[2], want[3]})
+		// A widened feed usually outgrows the extract it was authored with,
+		// and that extract is often SHARED — the eight original New York
+		// entries all name testdata/nyc-rail.geojson. Give the feed its own
+		// derived path so preflight can cut one to the new window without
+		// overwriting a fixture other feeds still read.
+		if rail := entry.Str("rail"); rail != "" && !strings.HasPrefix(rail, "build/") {
+			entry.Set("rail", "build/"+k+"-rail.geojson")
+		}
+		widened = append(widened, k)
+	}
+	return widened
+}
+
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case json.Number:
+		f, err := n.Float64()
+		return f, err == nil
+	}
+	return 0, false
+}
 
 // RewriteGroups mutates doc's "feeds" to carry exactly der's groups:
 // updated entries keep their key, curated name and position; groups the

--- a/internal/sync/run.go
+++ b/internal/sync/run.go
@@ -215,6 +215,11 @@ func Run(plan *Plan, o RunOpts) (*RunResult, error) {
 				oops(t.key, "preflight", err)
 				return
 			}
+		} else if err := feedPreflight(cfg, t.key, o.BuildDir, logf); err != nil {
+			// A plain feed whose window outgrew its extract: cut one from a
+			// wider extract rather than draw the railroad short.
+			oops(t.key, "preflight", err)
+			return
 		}
 		spec, err := assembleChart(doc, cfg, t.key, o.BuildDir, o.StyleDir, exportDir, logf)
 		if err != nil {
@@ -369,6 +374,9 @@ func Run(plan *Plan, o RunOpts) (*RunResult, error) {
 		return nil, fmt.Errorf("writing index.json: %w", err)
 	}
 	logf("index.json: %d feeds", len(idx))
+	if len(plan.Widened) > 0 {
+		logf("windows widened to cover their own shapes: %s", strings.Join(plan.Widened, " "))
+	}
 
 	if o.ExportDir != "" {
 		entries, err := os.ReadDir(o.ExportDir)

--- a/internal/sync/widen_test.go
+++ b/internal/sync/widen_test.go
@@ -1,0 +1,182 @@
+package sync
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A feed's bbox is the Overpass window AND the shape clip, so a window
+// smaller than the railroad truncates the map with no error at all.
+// Metro-North carried the subway's box — authored when portolan drew only
+// New York City — and came out with 25 of its 114 stations.
+func TestWidenFeedWindowsCoversTheFeedsOwnShapes(t *testing.T) {
+	doc, err := ParseDoc([]byte(`{"feeds":{
+	  "mta-metro-north":{"bbox":[-74.26,40.49,-73.7,40.92],"rail":"testdata/nyc-rail.geojson"},
+	  "mta-subway":{"bbox":[-74.26,40.49,-73.7,40.92],"rail":"testdata/nyc-rail.geojson"}
+	}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	der := &Derivation{Extent: map[string]Extent{
+		// the railroad as measured: north to Poughkeepsie, east to New Haven
+		"mta-metro-north": {-73.985, 40.753, -72.922, 41.815},
+		// the subway genuinely fits its authored window
+		"mta-subway": {-74.03, 40.58, -73.75, 40.90},
+	}}
+
+	widened := WidenFeedWindows(doc, der, nil)
+
+	if len(widened) != 1 || widened[0] != "mta-metro-north" {
+		t.Fatalf("widened = %v, want only mta-metro-north", widened)
+	}
+	bb := bboxOf(t, doc, "mta-metro-north")
+	// north and east must now reach the data (plus the margin groups use)
+	if bb[3] < 41.815 {
+		t.Errorf("north edge %v does not reach the railroad at 41.815", bb[3])
+	}
+	if bb[2] < -72.922 {
+		t.Errorf("east edge %v does not reach the railroad at -72.922", bb[2])
+	}
+	// widening only ever grows: the authored west/south still stand
+	if bb[0] > -74.26 || bb[1] > 40.49 {
+		t.Errorf("widening shrank the authored window: %v", bb)
+	}
+	// a feed that already fits is left exactly alone
+	if got := bboxOf(t, doc, "mta-subway"); got != [4]float64{-74.26, 40.49, -73.7, 40.92} {
+		t.Errorf("subway window moved: %v", got)
+	}
+}
+
+// The eight original New York entries all name one shared fixture. A widened
+// feed outgrows it, and must not rewrite a file the others still read.
+func TestWidenFeedWindowsRepointsASharedExtract(t *testing.T) {
+	doc, err := ParseDoc([]byte(`{"feeds":{
+	  "mta-metro-north":{"bbox":[-74.26,40.49,-73.7,40.92],"rail":"testdata/nyc-rail.geojson"},
+	  "nj-transit-rail":{"bbox":[-75.2,39.3,-73.9,41.5],"rail":"build/nj-transit-rail-rail.geojson"}
+	}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	der := &Derivation{Extent: map[string]Extent{
+		"mta-metro-north": {-73.985, 40.753, -72.922, 41.815},
+		"nj-transit-rail": {-75.1, 39.4, -74.0, 41.4},
+	}}
+	WidenFeedWindows(doc, der, nil)
+
+	if got := railOf(t, doc, "mta-metro-north"); got != "build/mta-metro-north-rail.geojson" {
+		t.Errorf("rail = %q, want its own derived extract", got)
+	}
+	// an untouched feed keeps whatever it had
+	if got := railOf(t, doc, "nj-transit-rail"); got != "build/nj-transit-rail-rail.geojson" {
+		t.Errorf("nj-transit rail moved: %q", got)
+	}
+}
+
+// Only feeds measured this run can be judged; a patch run must not widen a
+// feed on evidence it never gathered.
+func TestWidenFeedWindowsIgnoresUnmeasuredAndOutOfScope(t *testing.T) {
+	doc, err := ParseDoc([]byte(`{"feeds":{
+	  "a":{"bbox":[0,0,1,1]},
+	  "b":{"bbox":[0,0,1,1]}
+	}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	der := &Derivation{Extent: map[string]Extent{"a": {0, 0, 9, 9}, "b": {0, 0, 9, 9}}}
+
+	if got := WidenFeedWindows(doc, der, map[string]bool{"a": true}); len(got) != 1 || got[0] != "a" {
+		t.Fatalf("scope ignored: %v", got)
+	}
+	if bboxOf(t, doc, "b") != [4]float64{0, 0, 1, 1} {
+		t.Error("out-of-scope feed was widened")
+	}
+
+	// and a feed with no measurement at all is untouched
+	doc2, _ := ParseDoc([]byte(`{"feeds":{"c":{"bbox":[0,0,1,1]}}}`))
+	if got := WidenFeedWindows(doc2, &Derivation{Extent: map[string]Extent{}}, nil); len(got) != 0 {
+		t.Errorf("widened an unmeasured feed: %v", got)
+	}
+}
+
+// Clipping rather than merging is what keeps a widened feed affordable: the
+// Northeast Corridor extract is 166 MB, and a feed that swallowed it whole to
+// reach its own corner would chart as heavily as the whole corridor.
+func TestClipFCKeepsOnlyWhatMeetsTheWindow(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.geojson")
+	write(t, src, `{"type":"FeatureCollection","features":[
+	  {"type":"Feature","id":"inside","geometry":{"type":"LineString","coordinates":[[0.2,0.2],[0.4,0.4]]}},
+	  {"type":"Feature","id":"straddles","geometry":{"type":"LineString","coordinates":[[0.9,0.9],[2.0,2.0]]}},
+	  {"type":"Feature","id":"far","geometry":{"type":"LineString","coordinates":[[5.0,5.0],[6.0,6.0]]}},
+	  {"type":"Feature","id":"inside","geometry":{"type":"LineString","coordinates":[[0.1,0.1],[0.3,0.3]]}}
+	]}`)
+	dst := filepath.Join(dir, "out.geojson")
+
+	n, err := clipFC(dst, []string{src}, []float64{0, 0, 1, 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := idsOf(t, dst)
+	// the straddler is kept whole — the chart does the geometry clipping
+	if n != 2 || len(ids) != 2 || !ids["inside"] || !ids["straddles"] {
+		t.Fatalf("kept %v (n=%d), want inside + straddles", ids, n)
+	}
+	if ids["far"] {
+		t.Error("a feature outside the window was kept")
+	}
+}
+
+func bboxOf(t *testing.T, doc *Obj, key string) [4]float64 {
+	t.Helper()
+	v, _ := feedsObj(doc).Get(key)
+	bv, _ := v.(*Obj).Get("bbox")
+	arr, _ := bv.([]any)
+	if len(arr) != 4 {
+		t.Fatalf("%s: bbox is not 4 numbers: %v", key, bv)
+	}
+	var out [4]float64
+	for i, a := range arr {
+		f, ok := toFloat(a)
+		if !ok {
+			t.Fatalf("%s: bbox[%d] not a number", key, i)
+		}
+		out[i] = f
+	}
+	return out
+}
+
+func railOf(t *testing.T, doc *Obj, key string) string {
+	t.Helper()
+	v, _ := feedsObj(doc).Get(key)
+	return v.(*Obj).Str("rail")
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func idsOf(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fc struct {
+		Features []struct {
+			ID any `json:"id"`
+		} `json:"features"`
+	}
+	if err := json.Unmarshal(raw, &fc); err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]bool{}
+	for _, f := range fc.Features {
+		out[f.ID.(string)] = true
+	}
+	return out
+}


### PR DESCRIPTION
A global build was not global. Metro-North came out with **25 of its 114
stations** — everything past Yonkers missing, no error anywhere. LIRR the same:
44 of 127, clipped well short of Montauk.

## Why

A feed's `bbox` is the Overpass window *and* the shape clip. Eight feeds in the
registry — the original New York entries, authored when portolan drew only New
York City — all carry `[-74.26, 40.49, -73.7, 40.92]` and share
`testdata/nyc-rail.geojson`. For the subway, the ferries, the tram, the AirTrain
and the city buses that window is right. For Metro-North and LIRR it is not:
they are regional railroads reaching Poughkeepsie, New Haven and Montauk. Only
20 of Metro-North's 114 stops fall inside it.

Groups already take their window from measured data (`RewriteGroups`). Nothing
did the same for a plain feed, so a hand-authored window stayed wrong forever
and clipped the railroad away in silence.

## Changes

* `WidenFeedWindows` grows any measured feed's window until it contains the
  feed's own shapes, with the margin groups use. It only ever grows, and only
  when the window genuinely fails to contain the data — containment is judged
  *without* the margin on purpose, since adding slack first would nudge nearly
  every feed in the registry by a hair and every nudge is a rebuild.
* A widened feed is repointed off a shared extract onto `build/<key>-rail.geojson`,
  so cutting one to the new window cannot overwrite a fixture other feeds read.
* `feedPreflight` does for a plain feed what `groupPreflight` does for a group:
  when the extract does not cover the window, cut one that does. A group merges
  from its members; a lone feed borrows from any registry extract that covers
  the window and clips it. Sync still never calls Overpass.
* `clipFC` — merge with a window. Clipping rather than merging is what keeps
  this affordable: the Northeast Corridor extract is 166 MB, and a feed that
  swallowed it whole to reach its own corner would chart as heavily as the whole
  corridor. A feature straddling the edge is kept whole; the chart clips
  geometry itself.
* The run logs which windows it corrected, because silence is what let this sit.

## Tests

Four: the widening (Metro-North grows to its railroad, the subway — which
genuinely fits — is untouched), the repoint off a shared fixture, scope and
unmeasured feeds being left alone, and the clip keeping only what meets the
window.

Full suite green, `internal/stages` goldens included, so no drawn geometry moves.

## Note

This changes what a rebuild produces; it does not change anything already built.
The affected feeds need a rebuild for the missing stations to appear.