### PR TITLE
Make a corrected window reach the build

### DIFF
--- a/internal/sync/plan.go
+++ b/internal/sync/plan.go
@@ -202,6 +202,15 @@ func BuildPlan(o PlanOpts) (*Plan, error) {
 	// own railroad truncates the map silently. Widen before the entries are
 	// diffed, so a widened feed is dirty and rebuilds.
 	widened := WidenFeedWindows(after, der, scope)
+	// A widened window is a changed input even though the zip did not move:
+	// the feed's clip is different, so its build and any group drawing it are
+	// both stale. Without this the corrected window is computed and then
+	// discarded — the entry is only written when the registry is marked
+	// changed, and the feed only rebuilds when it counts as affected.
+	for _, k := range widened {
+		inC[k] = true
+		affected[k] = true
+	}
 
 	beforeFeeds := feedsObj(before)
 	afterFeeds := feedsObj(after)
@@ -212,6 +221,9 @@ func BuildPlan(o PlanOpts) (*Plan, error) {
 		return nil
 	}
 	plan := &Plan{Changed: changed, Measured: der.Measured, Derivation: der, Widened: widened}
+	if len(widened) > 0 {
+		plan.RegistryChanged = true
+	}
 	keptSet := map[string]bool{}
 	groupInputs := map[string][]string{} // key → member+overlay feeds (kept is 1:1 with scoped.Groups)
 	for i, k := range kept {

--- a/internal/sync/widen_test.go
+++ b/internal/sync/widen_test.go
@@ -180,3 +180,85 @@ func idsOf(t *testing.T, path string) map[string]bool {
 	}
 	return out
 }
+
+// Computing the corrected window is not enough: the entry is only written
+// when the registry counts as changed, and the feed only rebuilds when it
+// counts as affected. The first cut of this did neither, so a patch run
+// reported "registry rewrite: no" and skipped the very feeds it had just
+// corrected.
+func TestAWidenedWindowRebuildsAndIsWritten(t *testing.T) {
+	dir := t.TempDir()
+	raw := buildFixture(t, dir)
+	t.Chdir(dir)
+	cfg, doc := loadFixture(t, raw)
+
+	// Settle the registry first: a fresh fixture derives groups, and that
+	// alone marks the registry changed. Only on a settled registry is
+	// widening the sole reason anything moves — which is the case that
+	// failed in production.
+	settle, err := BuildPlan(PlanOpts{
+		Config: cfg, Doc: doc, State: &State{Feeds: map[string]FeedState{}},
+		Global: true, BuildDir: "build", Log: func(string, ...any) {},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settle.Registry == nil {
+		t.Fatal("fixture did not settle")
+	}
+	cfg2, doc2 := loadFixture(t, settle.Registry)
+	if again, err := BuildPlan(PlanOpts{
+		Config: cfg2, Doc: doc2, State: &State{Feeds: map[string]FeedState{}},
+		Global: true, BuildDir: "build", Log: func(string, ...any) {},
+	}); err != nil {
+		t.Fatal(err)
+	} else if again.RegistryChanged {
+		t.Fatal("registry still churning; the isolation this test needs does not hold")
+	}
+
+	// now clip "u" to a sliver of its own railroad, the way the New York
+	// entries clipped Metro-North
+	cfg3, doc3 := loadFixture(t, settle.Registry)
+	v, _ := feedsObj(doc3).Get("u")
+	v.(*Obj).Set("bbox", []any{-100.01, 39.99, -99.995, 40.01})
+	cfg3, _ = loadFixture(t, MarshalDoc(doc3))
+
+	plan, err := BuildPlan(PlanOpts{
+		Config: cfg3, Doc: doc3, State: &State{Feeds: map[string]FeedState{}},
+		Global: true, BuildDir: "build", Log: func(string, ...any) {},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !contains(plan.Widened, "u") {
+		t.Fatalf("Widened = %v, want it to carry u", plan.Widened)
+	}
+	// RegistryChanged is what makes the run WRITE the corrected window and
+	// re-parse it; without it the build reads the old file and the widening
+	// is computed and thrown away.
+	if !plan.RegistryChanged || plan.Registry == nil {
+		t.Fatal("a corrected window must mark the registry changed, or it is never written")
+	}
+	if !contains(plan.Standalone, "u") && !contains(plan.MemberPyramids, "u") {
+		t.Errorf("u was corrected but not scheduled to rebuild (standalone=%v members=%v)",
+			plan.Standalone, plan.MemberPyramids)
+	}
+	after, err := ParseDoc(plan.Registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bboxOf(t, after, "u")[2] <= -99.995 {
+		t.Errorf("written window still clips the railroad: %v", bboxOf(t, after, "u"))
+	}
+	_ = cfg2
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Follow-up to #34, caught deploying it: 0.4.6 computed the corrected windows and
then threw them away. A patch run for Metro-North and LIRR reported

```
registry rewrite:    no
mta-lirr: clean (built, tiled, exported) — skipped
mta-metro-north: clean (built, tiled, exported) — skipped
```

`WidenFeedWindows` mutated the planning document, but `plan.RegistryChanged` is
only ever set from group diffs. That flag is what makes the run write the
registry *and re-parse it into the config every build reads* (`run.go:124-136`).
With it false, the run re-read the old file, the widened bbox never reached the
chart argv, the build fingerprint was unchanged, and both feeds were skipped as
clean.

## Changes

* A widened window sets `RegistryChanged`, so the corrected registry is written
  and adopted.
* A widened feed joins the changed and affected sets — its clip moved even
  though its zip did not, so its own build and any group drawing it are stale.
  No-op on a global run, which already treats every feed as changed; it matters
  for a patch run.

## Test

`TestAWidenedWindowRebuildsAndIsWritten` settles the registry first, then clips
one feed to a sliver of its own railroad. Settling matters: on a fresh fixture
group derivation sets `RegistryChanged` on its own, and my first attempt at this
test passed against the broken code for exactly that reason. On a settled
registry, widening is the only thing that can move — and the test fails against
0.4.6 with "a corrected window must mark the registry changed, or it is never
written".

Full suite green, `internal/stages` goldens included.