### PR TITLE
Borrow the extract from the right feed

### DIFF
--- a/internal/sync/assemble.go
+++ b/internal/sync/assemble.go
@@ -433,11 +433,19 @@ func feedPreflight(cfg registry.Config, key, buildDir string,
 	if fc.Rail == "" || len(fc.BBox) != 4 || railCovers(fc.Rail, fc.BBox) {
 		return nil
 	}
-	// Widest first: one source that covers the whole window beats several
-	// that each cover a corner.
+	// A GROUP THIS FEED BELONGS TO FIRST. Its extract covers every member by
+	// construction and carries the same kind of railway, which no other test
+	// here can tell. Ranking by window size instead cut Metro-North's rail
+	// from a national intercity BUS feed — the widest window in the registry
+	// — and the build died with "no regular-service rail ways".
+	//
+	// Failing that, the SMALLEST covering extract: a minimal superset of this
+	// feed's own window is far likelier to be the regional railway it runs on
+	// than some continental network that happens to enclose it.
 	type cand struct {
-		path string
-		area float64
+		path  string
+		area  float64
+		owned bool // an extract belonging to a group this feed is a member of
 	}
 	var cands []cand
 	seen := map[string]bool{}
@@ -453,16 +461,28 @@ func feedPreflight(cfg registry.Config, key, buildDir string,
 			continue
 		}
 		seen[p] = true
-		a := 0.0
+		a := math.Inf(1)
 		if len(other.BBox) == 4 {
 			a = (other.BBox[2] - other.BBox[0]) * (other.BBox[3] - other.BBox[1])
 		}
-		cands = append(cands, cand{p, a})
+		owned := false
+		for _, m := range other.Members {
+			if m == key {
+				owned = true
+				break
+			}
+		}
+		cands = append(cands, cand{p, a, owned})
 	}
 	if len(cands) == 0 {
 		return fmt.Errorf("%s: rail extract at %s does not cover the window and no other extract covers it either", key, fc.Rail)
 	}
-	sort.Slice(cands, func(i, j int) bool { return cands[i].area > cands[j].area })
+	sort.Slice(cands, func(i, j int) bool {
+		if cands[i].owned != cands[j].owned {
+			return cands[i].owned
+		}
+		return cands[i].area < cands[j].area
+	})
 	dst := fc.Rail
 	if !strings.HasPrefix(dst, "build/") {
 		dst = filepath.Join(buildDir, key+"-rail.geojson")

--- a/internal/sync/widen_test.go
+++ b/internal/sync/widen_test.go
@@ -2,9 +2,13 @@ package sync
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/alexwohlbruck/portolan/internal/registry"
 )
 
 // A feed's bbox is the Overpass window AND the shape clip, so a window
@@ -261,4 +265,70 @@ func contains(xs []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// Which extract a widened feed borrows from decides whether it builds at all.
+// Ranking by window size cut Metro-North's rail from a national intercity BUS
+// feed — the widest window in the registry — and the build died with "no
+// regular-service rail ways in build/mta-metro-north-rail.geojson".
+func TestFeedPreflightBorrowsFromItsOwnGroup(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.MkdirAll("build", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// three extracts, all covering the feed's window
+	rail := func(name string, w, s, e, n float64) string {
+		p := filepath.Join("build", name)
+		write(t, p, `{"type":"FeatureCollection","features":[{"type":"Feature","id":"`+name+`",`+
+			`"geometry":{"type":"LineString","coordinates":[[`+ff(w)+`,`+ff(s)+`],[`+ff(e)+`,`+ff(n)+`]]}}]}`)
+		return p
+	}
+	// pad each past railCovers' 2 KB floor
+	pad := func(p string) {
+		raw, _ := os.ReadFile(p)
+		body := string(raw[:len(raw)-len("]}")])
+		for i := 0; i < 40; i++ {
+			body += `,{"type":"Feature","id":"pad` + ff(float64(i)) + `","geometry":{"type":"LineString","coordinates":[[-80,40],[-79,41]]}}`
+		}
+		write(t, p, body+"]}")
+	}
+	groupRail := rail("nec-rail.geojson", -76, 39, -71, 42)
+	busRail := rail("intercity-bus-rail.geojson", -125, 25, -66, 49)
+	ownRail := rail("mnr-rail.geojson", -74.3, 40.4, -73.6, 41.0) // too small: does not cover
+	for _, p := range []string{groupRail, busRail, ownRail} {
+		pad(p)
+	}
+
+	cfg, _ := loadFixtureCfg(t, `{"feeds":{
+	  "mta-metro-north":{"bbox":[-74.1,40.7,-72.9,41.9],"rail":"`+ownRail+`"},
+	  "northeast-corridor-region":{"bbox":[-76,39,-71,42],"rail":"`+groupRail+`","members":["mta-metro-north"]},
+	  "intercity-bus":{"bbox":[-125,25,-66,49],"rail":"`+busRail+`"}
+	}}`)
+
+	var logged string
+	if err := feedPreflight(cfg, "mta-metro-north", "build", func(f string, a ...any) {
+		logged += fmt.Sprintf(f, a...)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(logged, "nec-rail.geojson") {
+		t.Errorf("borrowed from the wrong extract: %q", logged)
+	}
+	if strings.Contains(logged, "intercity-bus") {
+		t.Error("borrowed from the continental bus network again")
+	}
+}
+
+func loadFixtureCfg(t *testing.T, raw string) (registry.Config, *Obj) {
+	t.Helper()
+	cfg, err := registry.Parse([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := ParseDoc([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg, doc
 }


### PR DESCRIPTION
Caught deploying 0.4.7. Both feeds it was meant to fix failed to build:

```
mta-metro-north: cut a rail extract to its window from
  build/utel-uiuc-intercity-bus-rail.geojson (19845 ways)
mta-metro-north: build: exit status 1 — portolan: no regular-service rail
  ways in build/mta-metro-north-rail.geojson
```

`feedPreflight` ranked candidate extracts by window area, widest first, on the
reasoning that one source covering the whole window beats several covering
corners. The widest window in the registry belongs to a national intercity
**bus** network, so that is what Metro-North's rail got cut from. It covers the
window and contains no regular-service rail at all.

## Changes

Ranking is now:

1. **An extract belonging to a group this feed is a member of.** It covers every
   member by construction and carries the same kind of railway — which nothing
   else here can test for.
2. **Otherwise the smallest covering extract.** A minimal superset of the feed's
   own window is far likelier to be the regional railway it runs on than some
   continental network that happens to enclose it.

## Test

`TestFeedPreflightBorrowsFromItsOwnGroup` puts three covering extracts in front
of the picker — the containing group's, a continental bus network's, and one too
small to qualify — and asserts it takes the group's. Against the old ranking it
fails with the same message production gave.

Full suite green.