### PR TITLE
Name each direction the way the signs do

### DIFF
--- a/internal/pipeline/directions_test.go
+++ b/internal/pipeline/directions_test.go
@@ -1,0 +1,184 @@
+package pipeline
+
+import (
+	"archive/zip"
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alexwohlbruck/portolan/internal/style"
+)
+
+func writeZip(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	for name, body := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+}
+
+func readZipFile(t *testing.T, path, want string) (string, bool) {
+	t.Helper()
+	zr, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zr.Close()
+	for _, e := range zr.File {
+		if filepath.Base(e.Name) == want {
+			r, err := e.Open()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer r.Close()
+			var sb strings.Builder
+			buf := make([]byte, 4096)
+			for {
+				n, err := r.Read(buf)
+				sb.Write(buf[:n])
+				if err != nil {
+					break
+				}
+			}
+			return sb.String(), true
+		}
+	}
+	return "", false
+}
+
+const mtaish = "route_id,agency_id,route_short_name,route_long_name\n" +
+	"4,MTA NYCT,4,Lexington Avenue Express\n" +
+	"L,MTA NYCT,L,14 St-Canarsie Local\n"
+
+const mtaTrips = "route_id,trip_id,direction_id,trip_headsign\n" +
+	"4,t1,0,Woodlawn\n4,t2,1,Crown Hts-Utica Av\n" +
+	"L,t3,0,8 Av\nL,t4,1,Canarsie-Rockaway Pkwy\n"
+
+// The MTA publishes no directions.txt at all — that is the case this exists
+// for. A feed that has none gains one, because direction_id is an opaque 0/1
+// until something names it.
+func TestExportNamesDirectionsAFeedDoesNotPublish(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "mta-subway.zip")
+	writeZip(t, src, map[string]string{"routes.txt": mtaish, "trips.txt": mtaTrips})
+
+	sty := style.New(style.Doc{
+		Agencies: map[string]style.Entity{
+			"MTA NYCT": {Directions: map[string]string{"0": "Uptown", "1": "Downtown"}},
+		},
+		Routes: map[string]style.Entity{
+			"L": {Directions: map[string]string{"0": "8 Av", "1": "Canarsie"}},
+		},
+	}.Config())
+
+	dirs, err := resolveDirections(src, sty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "out.zip")
+	if err := rewriteZip(src, dst, nil, dirs); err != nil {
+		t.Fatal(err)
+	}
+
+	body, ok := readZipFile(t, dst, "directions.txt")
+	if !ok {
+		t.Fatal("no directions.txt was written")
+	}
+	got := map[string]string{}
+	recs, err := csv.NewReader(strings.NewReader(body)).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range recs[1:] {
+		got[r[0]+"/"+r[1]] = r[2]
+	}
+	// the agency's naming reaches the 4...
+	if got["4/0"] != "Uptown" || got["4/1"] != "Downtown" {
+		t.Errorf("4 = %q/%q, want Uptown/Downtown", got["4/0"], got["4/1"])
+	}
+	// ...and the L says what the L's own signs say
+	if got["L/0"] != "8 Av" || got["L/1"] != "Canarsie" {
+		t.Errorf("L = %q/%q, want 8 Av/Canarsie", got["L/0"], got["L/1"])
+	}
+}
+
+// 367 of the 1499 feeds in the fleet already publish directions.txt. Curation
+// corrects rows without discarding the agency's own work.
+func TestExportMergesIntoAFeedsOwnDirections(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "feed.zip")
+	writeZip(t, src, map[string]string{
+		"routes.txt": mtaish,
+		"trips.txt":  mtaTrips,
+		"directions.txt": "route_id,direction_id,direction\n" +
+			"4,0,NORTHBOUND\n4,1,SOUTHBOUND\n",
+	})
+
+	sty := style.New(style.Doc{Routes: map[string]style.Entity{
+		"4": {Directions: map[string]string{"0": "Uptown"}},
+	}}.Config())
+
+	dirs, err := resolveDirections(src, sty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "out.zip")
+	if err := rewriteZip(src, dst, nil, dirs); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := readZipFile(t, dst, "directions.txt")
+	recs, err := csv.NewReader(strings.NewReader(body)).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, r := range recs[1:] {
+		got[r[0]+"/"+r[1]] = r[2]
+	}
+	if got["4/0"] != "Uptown" {
+		t.Errorf("4/0 = %q, want the curated Uptown", got["4/0"])
+	}
+	// the row nobody curated keeps the agency's own word
+	if got["4/1"] != "SOUTHBOUND" {
+		t.Errorf("4/1 = %q, want the feed's own SOUTHBOUND kept", got["4/1"])
+	}
+}
+
+// A pair nobody named is left out rather than guessed — a board showing the
+// wrong compass point is worse than one showing none.
+func TestExportWritesNothingWhenNothingIsNamed(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "feed.zip")
+	writeZip(t, src, map[string]string{"routes.txt": mtaish, "trips.txt": mtaTrips})
+
+	dirs, err := resolveDirections(src, style.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirs) != 0 {
+		t.Fatalf("named %d directions with no curation: %v", len(dirs), dirs)
+	}
+	dst := filepath.Join(dir, "out.zip")
+	if err := rewriteZip(src, dst, nil, dirs); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := readZipFile(t, dst, "directions.txt"); ok {
+		t.Error("wrote a directions.txt with nothing to say")
+	}
+}

--- a/internal/pipeline/export.go
+++ b/internal/pipeline/export.go
@@ -20,11 +20,13 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/alexwohlbruck/portolan/internal/geo"
 	"github.com/alexwohlbruck/portolan/internal/stages"
+	"github.com/alexwohlbruck/portolan/internal/style"
 )
 
 // exportGTFS writes one adjusted zip per source feed into dir. gtfsList is
@@ -86,11 +88,20 @@ func exportGTFS(dir, gtfsList string, paths []stages.Path, frame geo.Frame,
 			}
 		}
 		out := filepath.Join(dir, filepath.Base(src))
-		if err := rewriteZip(src, out, shapes); err != nil {
+		dirs, err := resolveDirections(src, style.Active())
+		if err != nil {
+			return fmt.Errorf("export %s: reading directions: %w", src, err)
+		}
+		if err := rewriteZip(src, out, shapes, dirs); err != nil {
 			return fmt.Errorf("export %s: %w", src, err)
 		}
-		logf("export: %s — %d shapes adjusted, %d clipped shapes kept as-is",
-			out, len(shapes), nclip)
+		if len(dirs) > 0 {
+			logf("export: %s — %d shapes adjusted, %d clipped shapes kept as-is, %d directions named",
+				out, len(shapes), nclip, len(dirs))
+		} else {
+			logf("export: %s — %d shapes adjusted, %d clipped shapes kept as-is",
+				out, len(shapes), nclip)
+		}
 	}
 	return nil
 }
@@ -116,7 +127,7 @@ func feedIndexOf(routeID string) int {
 // given; every other entry passes through byte-identical. A feed with no
 // shapes.txt gains one — pfaedle-less feeds exist, and the matched walk
 // is strictly better than nothing.
-func rewriteZip(src, dst string, shapes map[string][]geo.LL) error {
+func rewriteZip(src, dst string, shapes map[string][]geo.LL, dirs map[dirKey]string) error {
 	zr, err := zip.OpenReader(src)
 	if err != nil {
 		return err
@@ -130,6 +141,7 @@ func rewriteZip(src, dst string, shapes map[string][]geo.LL) error {
 	}
 	zw := zip.NewWriter(f)
 	sawShapes := false
+	sawDirections := false
 	for _, e := range zr.File {
 		name := filepath.Base(e.Name)
 		r, err := e.Open()
@@ -141,14 +153,32 @@ func rewriteZip(src, dst string, shapes map[string][]geo.LL) error {
 			r.Close()
 			return werr
 		}
-		if name == "shapes.txt" {
+		switch name {
+		case "shapes.txt":
 			sawShapes = true
 			err = filterShapes(r, w, shapes)
-		} else {
+		case "directions.txt":
+			// The feed already publishes one (367 of the 1499 in the fleet
+			// do). Curation overrides row by row and keeps the rest, so an
+			// agency that names three of four directions keeps its fourth.
+			sawDirections = true
+			err = mergeDirections(r, w, dirs)
+		default:
 			_, err = io.Copy(w, r)
 		}
 		r.Close()
 		if err != nil {
+			return err
+		}
+	}
+	// A feed with no directions.txt gains one, which is the MTA's case and
+	// the whole point: direction_id is an opaque 0/1 until something names it.
+	if !sawDirections && len(dirs) > 0 {
+		w, err := zw.Create("directions.txt")
+		if err != nil {
+			return err
+		}
+		if err := writeDirections(w, dirs); err != nil {
 			return err
 		}
 	}
@@ -224,6 +254,208 @@ func filterShapes(r io.Reader, w io.Writer, shapes map[string][]geo.LL) error {
 			if err := cw.Write(rec); err != nil {
 				return err
 			}
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+// ------------------------------------------------------- direction labels
+
+// dirKey identifies one direction of one route.
+type dirKey struct{ route, dir string }
+
+// resolveDirections names each (route, direction_id) the feed carries, using
+// the curation document. GTFS core has direction_id and nothing that says
+// what it means; a rider at Grand Central is reading a sign that says UPTOWN,
+// not one that says Woodlawn.
+//
+// Reads trips.txt for the pairs that actually exist and routes.txt for each
+// route's agency, so an agency-level naming reaches every route it runs. A
+// pair nobody named is left out rather than guessed.
+func resolveDirections(zipPath string, sty *style.Set) (map[dirKey]string, error) {
+	if sty == nil {
+		return nil, nil
+	}
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return nil, err
+	}
+	defer zr.Close()
+
+	rows := func(table string) ([]map[string]string, error) {
+		for _, e := range zr.File {
+			if filepath.Base(e.Name) != table {
+				continue
+			}
+			r, err := e.Open()
+			if err != nil {
+				return nil, err
+			}
+			defer r.Close()
+			cr := csv.NewReader(r)
+			cr.FieldsPerRecord = -1
+			head, err := cr.Read()
+			if err != nil {
+				return nil, err
+			}
+			for i, h := range head {
+				head[i] = strings.TrimSpace(strings.TrimPrefix(h, "\ufeff"))
+			}
+			var out []map[string]string
+			for {
+				rec, err := cr.Read()
+				if err != nil {
+					return out, nil
+				}
+				m := map[string]string{}
+				for i, h := range head {
+					if i < len(rec) {
+						m[h] = strings.TrimSpace(rec[i])
+					}
+				}
+				out = append(out, m)
+			}
+		}
+		return nil, nil
+	}
+
+	routes, err := rows("routes.txt")
+	if err != nil {
+		return nil, err
+	}
+	// route id → every identifier curation might name it by, and its agency
+	ids := map[string][]string{}
+	agency := map[string][]string{}
+	for _, r := range routes {
+		id := r["route_id"]
+		if id == "" {
+			continue
+		}
+		ids[id] = []string{id, r["route_short_name"], r["route_long_name"]}
+		agency[id] = []string{r["agency_id"]}
+	}
+
+	trips, err := rows("trips.txt")
+	if err != nil {
+		return nil, err
+	}
+	out := map[dirKey]string{}
+	for _, t := range trips {
+		k := dirKey{t["route_id"], t["direction_id"]}
+		if k.route == "" || k.dir == "" {
+			continue
+		}
+		if _, done := out[k]; done {
+			continue
+		}
+		if label, ok := sty.Direction(k.dir, ids[k.route], agency[k.route]); ok {
+			out[k] = label
+		}
+	}
+	return out, nil
+}
+
+// writeDirections emits directions.txt in the GTFS+ shape the extension
+// already uses — route_id, direction_id, direction — sorted so a rebuild of
+// unchanged inputs produces an unchanged file.
+func writeDirections(w io.Writer, dirs map[dirKey]string) error {
+	keys := make([]dirKey, 0, len(dirs))
+	for k := range dirs {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].route != keys[j].route {
+			return keys[i].route < keys[j].route
+		}
+		return keys[i].dir < keys[j].dir
+	})
+	cw := csv.NewWriter(w)
+	if err := cw.Write([]string{"route_id", "direction_id", "direction"}); err != nil {
+		return err
+	}
+	for _, k := range keys {
+		if err := cw.Write([]string{k.route, k.dir, dirs[k]}); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+// mergeDirections rewrites a feed's own directions.txt, replacing the rows
+// curation names and keeping every other row and column untouched. Rows we
+// name that the feed does not carry are appended.
+func mergeDirections(r io.Reader, w io.Writer, dirs map[dirKey]string) error {
+	cr := csv.NewReader(r)
+	cr.FieldsPerRecord = -1
+	head, err := cr.Read()
+	if err != nil {
+		return fmt.Errorf("directions.txt header: %w", err)
+	}
+	col := map[string]int{}
+	for i, h := range head {
+		col[strings.TrimSpace(strings.TrimPrefix(h, "\ufeff"))] = i
+	}
+	rc, ok1 := col["route_id"]
+	dc, ok2 := col["direction_id"]
+	lc, ok3 := col["direction"]
+	if !ok1 || !ok2 || !ok3 {
+		// A shape we do not understand is left exactly as it is rather than
+		// half-rewritten.
+		cw := csv.NewWriter(w)
+		if err := cw.Write(head); err != nil {
+			return err
+		}
+		for {
+			rec, err := cr.Read()
+			if err != nil {
+				cw.Flush()
+				return cw.Error()
+			}
+			if err := cw.Write(rec); err != nil {
+				return err
+			}
+		}
+	}
+	cw := csv.NewWriter(w)
+	if err := cw.Write(head); err != nil {
+		return err
+	}
+	seen := map[dirKey]bool{}
+	for {
+		rec, err := cr.Read()
+		if err != nil {
+			break
+		}
+		if rc < len(rec) && dc < len(rec) {
+			k := dirKey{strings.TrimSpace(rec[rc]), strings.TrimSpace(rec[dc])}
+			seen[k] = true
+			if label, ok := dirs[k]; ok && lc < len(rec) {
+				rec[lc] = label
+			}
+		}
+		if err := cw.Write(rec); err != nil {
+			return err
+		}
+	}
+	keys := make([]dirKey, 0, len(dirs))
+	for k := range dirs {
+		if !seen[k] {
+			keys = append(keys, k)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].route != keys[j].route {
+			return keys[i].route < keys[j].route
+		}
+		return keys[i].dir < keys[j].dir
+	})
+	for _, k := range keys {
+		rec := make([]string, len(head))
+		rec[rc], rec[dc], rec[lc] = k.route, k.dir, dirs[k]
+		if err := cw.Write(rec); err != nil {
+			return err
 		}
 	}
 	cw.Flush()

--- a/internal/style/directions_test.go
+++ b/internal/style/directions_test.go
@@ -1,0 +1,88 @@
+package style
+
+import "testing"
+
+// A rider at Grand Central reads a sign that says UPTOWN, not one that says
+// Woodlawn. GTFS core carries direction_id — an opaque 0/1 — and nothing
+// that names it, so the name is curation.
+func TestDirectionNamesEachDirectionID(t *testing.T) {
+	s := New(Doc{Routes: map[string]Entity{
+		"4": {Directions: map[string]string{"0": "Uptown", "1": "Downtown"}},
+	}}.Config())
+
+	if got, ok := s.Direction("0", []string{"4"}, nil); !ok || got != "Uptown" {
+		t.Errorf(`Direction("0") = %q,%v — want "Uptown"`, got, ok)
+	}
+	if got, ok := s.Direction("1", []string{"4"}, nil); !ok || got != "Downtown" {
+		t.Errorf(`Direction("1") = %q,%v — want "Downtown"`, got, ok)
+	}
+	// A direction nobody named is reported missing rather than guessed: a
+	// board showing the wrong compass point is worse than one showing none.
+	if got, ok := s.Direction("2", []string{"4"}, nil); ok {
+		t.Errorf(`Direction("2") = %q — want no answer`, got)
+	}
+	if _, ok := s.Direction("0", []string{"L"}, nil); ok {
+		t.Error("an unnamed route borrowed another route's directions")
+	}
+}
+
+// An operator whose whole network runs Inbound/Outbound says it once; a
+// route that needs something truer overrides it.
+func TestDirectionRouteBeatsAgency(t *testing.T) {
+	s := New(Doc{
+		Agencies: map[string]Entity{
+			"MTA NYCT": {Directions: map[string]string{"0": "Uptown", "1": "Downtown"}},
+		},
+		Routes: map[string]Entity{
+			"L": {Directions: map[string]string{"0": "8 Av", "1": "Canarsie"}},
+		},
+	}.Config())
+
+	// the L says what the L's signs say
+	if got, _ := s.Direction("0", []string{"L"}, []string{"MTA NYCT"}); got != "8 Av" {
+		t.Errorf("L direction 0 = %q, want 8 Av", got)
+	}
+	// every other route falls through to the agency
+	if got, _ := s.Direction("0", []string{"4"}, []string{"MTA NYCT"}); got != "Uptown" {
+		t.Errorf("4 direction 0 = %q, want Uptown", got)
+	}
+	// and a route that names only one direction still inherits the other
+	if got, _ := s.Direction("1", []string{"L"}, []string{"MTA NYCT"}); got != "Canarsie" {
+		t.Errorf("L direction 1 = %q, want Canarsie", got)
+	}
+}
+
+// Documents layer global-then-city, and a city naming one direction must not
+// wipe what the global document said about the other.
+func TestDirectionLayersPerDirectionID(t *testing.T) {
+	global := Doc{Agencies: map[string]Entity{
+		"MTA NYCT": {Directions: map[string]string{"0": "Northbound", "1": "Southbound"}},
+	}}.Config()
+	city := Doc{Agencies: map[string]Entity{
+		"MTA NYCT": {Directions: map[string]string{"0": "Uptown"}},
+	}}.Config()
+
+	s := New(global, city)
+	if got, _ := s.Direction("0", nil, []string{"MTA NYCT"}); got != "Uptown" {
+		t.Errorf("direction 0 = %q, want the city's Uptown", got)
+	}
+	if got, _ := s.Direction("1", nil, []string{"MTA NYCT"}); got != "Southbound" {
+		t.Errorf("direction 1 = %q, want the global Southbound to survive", got)
+	}
+}
+
+// Flattening must not alias the caller's document — the resolver writes into
+// its own merged copy.
+func TestDirectionConfigDoesNotAliasTheDocument(t *testing.T) {
+	doc := Doc{Routes: map[string]Entity{
+		"4": {Directions: map[string]string{"0": "Uptown"}},
+	}}
+	cfg := doc.Config()
+	New(cfg, Doc{Routes: map[string]Entity{
+		"4": {Directions: map[string]string{"0": "Something else"}},
+	}}.Config())
+
+	if got := doc.Routes["4"].Directions["0"]; got != "Uptown" {
+		t.Errorf("the source document was mutated: %q", got)
+	}
+}

--- a/internal/style/load.go
+++ b/internal/style/load.go
@@ -95,6 +95,25 @@ type Entity struct {
 	// narrows the colour policy's reach. Empty — every real-world feed —
 	// leaves the key the bare colour, byte for byte.
 	TrunkGroup string `json:"trunk_group,omitempty"`
+	// Directions names each direction_id the way the signs do, keyed by the
+	// GTFS direction_id as a string: {"0": "Uptown", "1": "Downtown"}. A
+	// rider at Grand Central is reading a sign that says UPTOWN, not one
+	// that says Woodlawn, so a board that only shows the headsign makes
+	// them work out which way that is.
+	//
+	// This is curation because the data does not carry it. GTFS core has
+	// direction_id — an opaque 0/1 with no meaning attached — and the
+	// directions.txt extension, which 367 of the 1499 feeds in the fleet
+	// publish and the MTA does not. Where a feed does publish one it is
+	// read as the starting point; this overrides it, and supplies it where
+	// there is none.
+	//
+	// On an agency it covers every route the agency runs; on a route it
+	// beats the agency. Both are useful: an operator whose whole network
+	// runs Inbound/Outbound says it once, while the MTA needs the L to say
+	// "8 Av"/"Canarsie" where the Lexington Avenue lines say
+	// "Uptown"/"Downtown".
+	Directions map[string]string `json:"directions,omitempty"`
 	// RouteType REPAIRS a feed's route_type where the agency mistyped it —
 	// Mexico City files the Tren Suburbano (a commuter railway) as
 	// route_type 1, and everything downstream then demands metro-class
@@ -181,6 +200,18 @@ func (d Doc) Config() Config {
 					c.Hiddens = map[string]bool{}
 				}
 				c.Hiddens[key] = true
+			}
+			if len(e.Directions) > 0 {
+				if c.Directions == nil {
+					c.Directions = map[string]map[string]string{}
+				}
+				// copied, not aliased: the resolver layers documents over
+				// each other and must not write through into a caller's doc
+				m := make(map[string]string, len(e.Directions))
+				for d, label := range e.Directions {
+					m[d] = label
+				}
+				c.Directions[key] = m
 			}
 			if e.Name != "" {
 				if c.Names == nil {

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -130,6 +130,11 @@ type Config struct {
 	RouteTypes map[string]int `json:"route_types,omitempty"`
 	// Hiddens: routes/agencies dropped from the build (Entity.Hidden).
 	Hiddens map[string]bool `json:"hiddens,omitempty"`
+	// Directions: direction_id → the name on the sign, keyed like Colors.
+	// Nested rather than flattened into one key because direction_id is a
+	// second dimension, not part of the subject's identity, and a route id
+	// may itself contain the ':' any flat separator would have to survive.
+	Directions map[string]map[string]string `json:"directions,omitempty"`
 	// BulletOrder: one of the Bullets* policies above. Empty inherits
 	// (default BulletsColor).
 	BulletOrder string `json:"bullet_order,omitempty"`
@@ -200,6 +205,8 @@ type Set struct {
 	RouteTypes map[string]int `json:"route_types,omitempty"`
 	// Hiddens: routes/agencies dropped from the build (Entity.Hidden).
 	Hiddens map[string]bool `json:"hiddens,omitempty"`
+	// Directions: resolved direction_id → sign name, keyed like Colors.
+	Directions map[string]map[string]string `json:"directions,omitempty"`
 	// BulletOrder: resolved Bullets* policy, never empty.
 	BulletOrder string `json:"bullet_order"`
 	// Caterpillars: resolved on/off for inline route bullets.
@@ -229,6 +236,8 @@ type Set struct {
 	rtRoute  map[string]int
 	hAgency2 map[string]bool
 	hRoute2  map[string]bool
+	dAgency  map[string]map[string]string
+	dRoute   map[string]map[string]string
 }
 
 // New resolves configs in precedence order — later ones win field by field.
@@ -251,7 +260,8 @@ func New(layers ...Config) *Set {
 		tAgency: map[string]string{}, tRoute: map[string]string{},
 		gAgency: map[string]string{}, gRoute: map[string]string{},
 		rtAgency: map[string]int{}, rtRoute: map[string]int{},
-		hAgency2: map[string]bool{}, hRoute2: map[string]bool{}}
+		hAgency2: map[string]bool{}, hRoute2: map[string]bool{},
+		dAgency: map[string]map[string]string{}, dRoute: map[string]map[string]string{}}
 	for name, d := range defaults {
 		merged := d
 		for _, l := range layers {
@@ -290,6 +300,21 @@ func New(layers ...Config) *Set {
 		}
 		for k, v := range l.TrunkGroups {
 			s.TrunkGroups[k] = v
+		}
+		for k, v := range l.Directions {
+			if s.Directions == nil {
+				s.Directions = map[string]map[string]string{}
+			}
+			// merge per direction_id: a city naming only direction 0 keeps
+			// whatever the global document said about direction 1
+			cur := s.Directions[k]
+			if cur == nil {
+				cur = map[string]string{}
+				s.Directions[k] = cur
+			}
+			for d, label := range v {
+				cur[d] = label
+			}
 		}
 		for k, v := range l.RouteTypes {
 			if s.RouteTypes == nil {
@@ -379,6 +404,24 @@ func New(layers ...Config) *Set {
 			s.gRoute[strings.TrimPrefix(key, "route:")] = val
 		}
 	}
+	for k, v := range s.Directions {
+		key := strings.ToLower(strings.TrimSpace(k))
+		labels := map[string]string{}
+		for d, label := range v {
+			if label = strings.TrimSpace(label); label != "" {
+				labels[strings.TrimSpace(d)] = label
+			}
+		}
+		if len(labels) == 0 {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(key, "agency:"):
+			s.dAgency[strings.TrimPrefix(key, "agency:")] = labels
+		case strings.HasPrefix(key, "route:"):
+			s.dRoute[strings.TrimPrefix(key, "route:")] = labels
+		}
+	}
 	for k, v := range s.RouteTypes {
 		key := strings.ToLower(strings.TrimSpace(k))
 		switch {
@@ -444,6 +487,45 @@ func (s *Set) Class(name string) Resolved {
 		return r
 	}
 	return s.Modes["unknown"]
+}
+
+// Direction is the name on the sign for one direction_id — "Uptown" for
+// the 4 train's direction 0. A route's own naming beats its agency's, so
+// an operator can say Inbound/Outbound once for the whole network and
+// still let one line say something truer.
+//
+// dirID is the GTFS direction_id as its string ("0"/"1"). Reported missing
+// rather than guessed: there is no default worth inventing, and a board
+// showing the wrong compass point is worse than one showing none.
+func (s *Set) Direction(dirID string, routeIDs, agencyIDs []string) (string, bool) {
+	if s == nil {
+		return "", false
+	}
+	dirID = strings.TrimSpace(dirID)
+	if dirID == "" {
+		return "", false
+	}
+	if v, ok := lookupDirection(s.dRoute, routeIDs, dirID); ok {
+		return v, true
+	}
+	return lookupDirection(s.dAgency, agencyIDs, dirID)
+}
+
+func lookupDirection(tbl map[string]map[string]string, ids []string, dirID string) (string, bool) {
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(id))
+		for _, k := range []string{key, unprefix(key)} {
+			if labels, ok := tbl[k]; ok {
+				if v, ok := labels[dirID]; ok {
+					return v, true
+				}
+			}
+		}
+	}
+	return "", false
 }
 
 // RouteColor is the color override for a route, if any. Every identifier

--- a/web/src/views/StyleView.vue
+++ b/web/src/views/StyleView.vue
@@ -198,6 +198,69 @@ function addName(key: string, name: string) {
   nameAddOpen.value = false
 }
 
+// ── direction labels ──────────────────────────────────────────────────
+// GTFS carries direction_id — an opaque 0/1 — and nothing that says what it
+// means. A rider at Grand Central is reading a sign that says UPTOWN, not one
+// that says Woodlawn, so the name is curation like colour. Set it on an
+// agency to cover its whole network, on a route to say something truer for
+// one line. It rides out in the corrected feed's directions.txt.
+const dirAddOpen = ref(false)
+const newDirKey = ref('')
+const newDirKind = ref('route')
+const newDirId = ref('0')
+const newDirLabel = ref('')
+
+/** every subject that names a direction, one row per direction_id */
+const directionRows = computed(() => {
+  const out: { kind: Kind; key: string; dir: string; label: string }[] = []
+  for (const k of KINDS) {
+    const m = (layer.value as any)[bucket(k)] ?? {}
+    for (const [name, ent] of Object.entries(m as Record<string, any>)) {
+      const d = ent?.directions
+      if (!d) continue
+      for (const dir of Object.keys(d).sort()) {
+        if (d[dir]) out.push({ kind: k, key: name, dir, label: String(d[dir]) })
+      }
+    }
+  }
+  return out
+})
+
+function setDirection(kind: Kind, key: string, dir: string, label: string) {
+  const doc = layer.value as any
+  const m = (doc[bucket(kind)] ??= {})
+  const ent = (m[key] ??= {})
+  const d = (ent.directions ??= {})
+  if (!label.trim()) delete d[dir]
+  else d[dir] = label.trim()
+  if (!Object.keys(d).length) delete ent.directions
+  if (!Object.keys(ent).length) delete m[key]
+}
+function dropDirection(kind: Kind, key: string, dir: string) {
+  setDirection(kind, key, dir, '')
+}
+
+async function openDirAdd() {
+  dirAddOpen.value = true
+  newDirKey.value = ''
+  newDirLabel.value = ''
+  newDirId.value = '0'
+  newDirKind.value = 'route'
+  if (!routes.value.length && feed.value) {
+    try {
+      routes.value = await api.routes(feed.value)
+    } catch {
+      /* the picker is a convenience; typing a key still works */
+    }
+  }
+}
+function addDirection(key: string, dir: string, label: string) {
+  if (!key || !label.trim()) return
+  const [kind, subj] = splitKey(key)
+  setDirection(kind, subj, dir.trim() || '0', label)
+  dirAddOpen.value = false
+}
+
 /** caterpillars tri-state for the active layer: '' = inherit, 'on', 'off' */
 const catState = computed<string>(() => {
   const v = layer.value.options?.caterpillars
@@ -483,12 +546,127 @@ const overrideCount = computed(
         </CardContent>
       </Card>
 
+      <Card>
+        <CardHeader class="flex-row items-center justify-between pb-3">
+          <div>
+            <CardTitle class="text-sm">Direction labels</CardTitle>
+            <CardDescription>
+              Name each direction the way the signs do — the 4 train runs Uptown and Downtown, not 0 and 1. GTFS
+              carries direction_id and nothing that says what it means. An agency label covers every route it runs;
+              a route label beats it, so the L can say 8 Av and Canarsie while the rest say Uptown and Downtown.
+            </CardDescription>
+          </div>
+          <Button variant="outline" size="sm" @click="openDirAdd"><Plus class="size-4" /> Add</Button>
+        </CardHeader>
+        <CardContent>
+          <div v-if="!directionRows.length" class="flex flex-col items-center gap-2 py-10 text-muted-foreground">
+            <span class="text-sm">No labels — boards show the headsign alone.</span>
+          </div>
+          <div v-else class="grid gap-2">
+            <div
+              v-for="row in directionRows"
+              :key="`${row.kind}:${row.key}:${row.dir}`"
+              class="flex items-center gap-3 rounded-lg border border-border px-3 py-2"
+            >
+              <Badge variant="muted" class="shrink-0 text-[10px]">{{ row.kind }}</Badge>
+              <span class="min-w-0 flex-1 truncate text-sm text-muted-foreground">{{ row.key }}</span>
+              <Badge variant="secondary" class="shrink-0 font-mono text-[10px]">dir {{ row.dir }}</Badge>
+              <span class="shrink-0 text-muted-foreground">→</span>
+              <Input
+                class="h-8 w-40 text-xs"
+                :model-value="row.label"
+                @update:model-value="(v) => setDirection(row.kind, row.key, row.dir, v)"
+              />
+              <Button variant="ghost" size="icon" @click="dropDirection(row.kind, row.key, row.dir)"><Trash2 class="size-4" /></Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
       <div class="text-xs text-muted-foreground">
         {{ overrideCount }} override{{ overrideCount === 1 ? '' : 's' }} in the {{ scope }} layer.
         Changes apply on the next build.
       </div>
     </template>
   </div>
+
+  <Dialog
+    :open="dirAddOpen"
+    title="Add direction label"
+    description="Pick an agency or route, choose which direction_id it names, and type what the signs say."
+    @update:open="(v) => (dirAddOpen = v)"
+  >
+    <div class="flex flex-col gap-4">
+      <div class="flex gap-2">
+        <div class="relative flex-1">
+          <Search class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input v-model="routeQuery" placeholder="Search routes and agencies" class="pl-9" />
+        </div>
+        <select
+          v-model="newDirId"
+          class="h-9 w-24 rounded-md border border-border bg-background px-2 font-mono text-sm"
+          aria-label="direction_id"
+        >
+          <option value="0">dir 0</option>
+          <option value="1">dir 1</option>
+        </select>
+        <Input v-model="newDirLabel" placeholder="Uptown" class="w-40" />
+      </div>
+
+      <div class="max-h-72 overflow-y-auto rounded-lg border border-border">
+        <div v-if="agencies.length" class="border-b border-border bg-muted/40 px-3 py-1.5 text-xs font-medium text-muted-foreground">
+          Agencies
+        </div>
+        <button
+          v-for="a in agencies"
+          :key="a.name"
+          class="flex w-full items-center gap-2 border-b border-border/50 px-3 py-2 text-left text-sm last:border-0 hover:bg-accent/40"
+          @click="addDirection(`agency:${a.name}`, newDirId, newDirLabel)"
+        >
+          <Badge variant="secondary" class="text-[10px] capitalize">{{ a.mode }}</Badge>
+          <span class="truncate">{{ a.name }}</span>
+        </button>
+
+        <div class="border-y border-border bg-muted/40 px-3 py-1.5 text-xs font-medium text-muted-foreground">
+          Routes
+        </div>
+        <button
+          v-for="r in filteredRoutes"
+          :key="r.id"
+          class="flex w-full items-center gap-2 border-b border-border/50 px-3 py-2 text-left text-sm last:border-0 hover:bg-accent/40"
+          @click="addDirection(`route:${r.short_name || r.id}`, newDirId, newDirLabel)"
+        >
+          <span class="w-14 shrink-0 truncate font-medium">{{ r.short_name || r.id }}</span>
+          <span class="min-w-0 flex-1 truncate text-muted-foreground">{{ r.long_name }}</span>
+          <Badge variant="muted" class="shrink-0 text-[10px] capitalize">{{ r.mode }}</Badge>
+        </button>
+      </div>
+
+      <div class="flex items-end gap-2">
+        <div class="flex w-32 flex-col gap-1.5">
+          <Label for="dirkind">Kind</Label>
+          <select
+            id="dirkind"
+            v-model="newDirKind"
+            class="h-9 rounded-md border border-border bg-background px-2 text-sm"
+          >
+            <option value="route">route</option>
+            <option value="agency">agency</option>
+          </select>
+        </div>
+        <div class="flex flex-1 flex-col gap-1.5">
+          <Label for="rawdirkey">Or type a key</Label>
+          <Input id="rawdirkey" v-model="newDirKey" placeholder="MTA NYCT" class="font-mono" />
+        </div>
+        <Button
+          :disabled="!newDirKey || !newDirLabel.trim()"
+          @click="addDirection(`${newDirKind}:${newDirKey}`, newDirId, newDirLabel)"
+        >
+          Add
+        </Button>
+      </div>
+    </div>
+  </Dialog>
 
   <Dialog
     :open="addOpen"


### PR DESCRIPTION
A departure board that reads "Woodlawn" makes a rider work out which way that
is. The sign they are standing under says **UPTOWN**. Apple shows "Uptown to
Woodlawn"; this is the data to do the same.

## What the feeds actually carry

I checked, rather than assuming:

* The MTA subway feed has `route_id, trip_id, service_id, trip_headsign,
  direction_id, shape_id` and nothing else. No `directions.txt`, and
  `stop_times.txt` has no `stop_headsign` column at all. "Uptown" appears
  nowhere in it.
* `direction_id` does split cleanly — the 4's direction 0 is Woodlawn /
  Bedford Park / 149 St, direction 1 is Bowling Green / Crown Hts / New Lots.
  So the split is real; only the word is missing.
* `directions.txt` is a GTFS **extension**, not core, and **367 of the 1499
  feeds** in the fleet publish one. Its vocabulary is agency-chosen and messy:
  `NORTHBOUND`, `Inbound`, `Loop`, `CIRCULATOR`, and in one feed `Inound` and
  `Outbound ` with a trailing space.

So this is curation, exactly like colour: the data does not carry it and there
is no signal to compute it from.

## Changes

**Style** — `Entity.Directions`, a `direction_id → label` map on any agency,
route or stop entry. An agency naming covers every route it runs; a route
naming beats it, so an operator says Inbound/Outbound once while the MTA lets
the L say "8 Av"/"Canarsie" where the Lexington Avenue lines say
"Uptown"/"Downtown". Documents layer per direction_id, so a city naming
direction 0 keeps what the global document said about direction 1.

Nested rather than flattened into one key, because direction_id is a second
dimension rather than part of the subject's identity — and a route id may
itself contain the `:` any flat separator would have had to survive.

**Pipeline** — the corrected feed now carries `directions.txt`. A feed with
none gains one (the MTA's case); a feed that publishes one has the named rows
replaced and every other row and column kept, so an agency that names three of
four directions keeps its fourth. A pair nobody named is left out rather than
guessed: a board showing the wrong compass point is worse than one showing
none. Output is sorted, so an unchanged input rebuilds byte-identically.

**Console** — a Direction labels card on the Style page, alongside colours and
names: pick an agency or route, choose the direction_id, type what the signs
say. Edit and delete inline like the others.

## Tests

Seven. Four on resolution (route beats agency, per-direction layering, an
unnamed direction reported missing rather than guessed, and flattening not
aliasing the caller's document) and three on export (a feed that publishes
none gains one, a feed that does gets merged not replaced, and nothing is
written when nothing is named).

Full Go suite green, `internal/stages` goldens included. Console typechecks
and builds.

## Note

This writes the label into the corrected GTFS. Barrelman ingesting
`directions.txt` and putting "Uptown to Woodlawn" on the board is separate
work, not in here.