### PR TITLE
Name the MTA's directions

### DIFF
--- a/style/mta-subway.json
+++ b/style/mta-subway.json
@@ -1,5 +1,75 @@
 {
   "options": {
     "osm_stop_names": false
+  },
+  "agencies": {
+    "MTA NYCT": {
+      "directions": {
+        "0": "Uptown",
+        "1": "Downtown"
+      }
+    }
+  },
+  "routes": {
+    "7": {
+      "directions": {
+        "0": "Queens",
+        "1": "Manhattan"
+      }
+    },
+    "7X": {
+      "directions": {
+        "0": "Queens",
+        "1": "Manhattan"
+      }
+    },
+    "G": {
+      "directions": {
+        "0": "Queens",
+        "1": "Brooklyn"
+      }
+    },
+    "L": {
+      "directions": {
+        "0": "Manhattan",
+        "1": "Brooklyn"
+      }
+    },
+    "J": {
+      "directions": {
+        "0": "Jamaica",
+        "1": "Manhattan"
+      }
+    },
+    "Z": {
+      "directions": {
+        "0": "Jamaica",
+        "1": "Manhattan"
+      }
+    },
+    "GS": {
+      "directions": {
+        "0": "Times Sq",
+        "1": "Grand Central"
+      }
+    },
+    "FS": {
+      "directions": {
+        "0": "Franklin Av",
+        "1": "Prospect Park"
+      }
+    },
+    "H": {
+      "directions": {
+        "0": "Broad Channel",
+        "1": "Rockaway Park"
+      }
+    },
+    "SI": {
+      "directions": {
+        "0": "St George",
+        "1": "Tottenville"
+      }
+    }
   }
 }


### PR DESCRIPTION
Uptown/Downtown for the agency, with the lines that is wrong for named one by one — verified against each route's own headsigns per direction_id rather than assumed:

- **7, G, L** run crosstown; the signs name the borough, not a compass point.
- **J, Z** run Jamaica to Manhattan.
- **GS, FS, H** are shuttles between two named places.
- **SI** (Staten Island Railway) is its own line, not part of the uptown grid.

Everything else — the numbered lines, A/B/C/D, N/Q/R/W, E/F/M — is genuinely uptown and downtown through Manhattan and takes the agency default.

Editable in the console's Style page without a release.