### PR TITLE
Keep the geometry when clipping

### DIFF
--- a/internal/sync/assemble.go
+++ b/internal/sync/assemble.go
@@ -365,20 +365,28 @@ func clipFC(dst string, srcs []string, bbox []float64) (int, error) {
 		if err != nil {
 			return 0, err
 		}
+		// The geometry is decoded ONCE, as the raw message that goes back
+		// out. An earlier cut of this embedded `feature` beside a second
+		// field also tagged "geometry"; Go resolves that conflict in favour
+		// of the shallower field, so the embedded one stayed nil and every
+		// clipped feature was written with "geometry":null. The extract had
+		// the right ways in it and no shape at all, and the chart reported
+		// "no regular-service rail ways".
 		var fc struct {
-			Features []struct {
-				feature
-				Geometry struct {
-					Type        string          `json:"type"`
-					Coordinates json.RawMessage `json:"coordinates"`
-				} `json:"geometry"`
-			} `json:"features"`
+			Features []feature `json:"features"`
 		}
 		if err := json.Unmarshal(raw, &fc); err != nil {
 			return 0, fmt.Errorf("%s: %w", src, err)
 		}
 		for _, f := range fc.Features {
-			w, s2, e, n, ok := featureBBox(f.Geometry.Type, f.Geometry.Coordinates)
+			var g struct {
+				Type        string          `json:"type"`
+				Coordinates json.RawMessage `json:"coordinates"`
+			}
+			if len(f.Geom) == 0 || json.Unmarshal(f.Geom, &g) != nil {
+				continue
+			}
+			w, s2, e, n, ok := featureBBox(g.Type, g.Coordinates)
 			if !ok || w > bbox[2] || e < bbox[0] || s2 > bbox[3] || n < bbox[1] {
 				continue
 			}
@@ -389,7 +397,7 @@ func clipFC(dst string, srcs []string, bbox []float64) (int, error) {
 				}
 				seen[id] = true
 			}
-			feats = append(feats, f.feature)
+			feats = append(feats, f)
 		}
 	}
 	out := struct {
@@ -475,7 +483,13 @@ func feedPreflight(cfg registry.Config, key, buildDir string,
 		cands = append(cands, cand{p, a, owned})
 	}
 	if len(cands) == 0 {
-		return fmt.Errorf("%s: rail extract at %s does not cover the window and no other extract covers it either", key, fc.Rail)
+		// Nothing to cut from. The feed keeps the extract it has and draws
+		// what that covers, which is what it did before this step existed —
+		// a partial railroad beats refusing to build. Continental feeds are
+		// the normal case here: Amtrak's and VIA's windows are larger than
+		// any single extract in the registry.
+		logf("%s: window reaches past its rail extract and nothing else covers it — drawing what the extract has", key)
+		return nil
 	}
 	sort.Slice(cands, func(i, j int) bool {
 		if cands[i].owned != cands[j].owned {

--- a/internal/sync/widen_test.go
+++ b/internal/sync/widen_test.go
@@ -110,11 +110,13 @@ func TestWidenFeedWindowsIgnoresUnmeasuredAndOutOfScope(t *testing.T) {
 func TestClipFCKeepsOnlyWhatMeetsTheWindow(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src.geojson")
+	// tags included: they are what classifies a way as regular-service rail,
+	// so an extract that keeps geometry and drops properties is still useless
 	write(t, src, `{"type":"FeatureCollection","features":[
-	  {"type":"Feature","id":"inside","geometry":{"type":"LineString","coordinates":[[0.2,0.2],[0.4,0.4]]}},
-	  {"type":"Feature","id":"straddles","geometry":{"type":"LineString","coordinates":[[0.9,0.9],[2.0,2.0]]}},
-	  {"type":"Feature","id":"far","geometry":{"type":"LineString","coordinates":[[5.0,5.0],[6.0,6.0]]}},
-	  {"type":"Feature","id":"inside","geometry":{"type":"LineString","coordinates":[[0.1,0.1],[0.3,0.3]]}}
+	  {"type":"Feature","id":"inside","properties":{"railway":"rail","usage":"main"},"geometry":{"type":"LineString","coordinates":[[0.2,0.2],[0.4,0.4]]}},
+	  {"type":"Feature","id":"straddles","properties":{"railway":"rail"},"geometry":{"type":"LineString","coordinates":[[0.9,0.9],[2.0,2.0]]}},
+	  {"type":"Feature","id":"far","properties":{"railway":"rail"},"geometry":{"type":"LineString","coordinates":[[5.0,5.0],[6.0,6.0]]}},
+	  {"type":"Feature","id":"inside","properties":{"railway":"rail"},"geometry":{"type":"LineString","coordinates":[[0.1,0.1],[0.3,0.3]]}}
 	]}`)
 	dst := filepath.Join(dir, "out.geojson")
 
@@ -129,6 +131,18 @@ func TestClipFCKeepsOnlyWhatMeetsTheWindow(t *testing.T) {
 	}
 	if ids["far"] {
 		t.Error("a feature outside the window was kept")
+	}
+	// AND the geometry must survive. The first cut of clipFC wrote every
+	// feature with "geometry":null — the right ways with no shape — and the
+	// chart reported "no regular-service rail ways". Asserting on ids alone
+	// is what let that reach production.
+	for _, f := range featuresOf(t, dst) {
+		if len(f.Geom) == 0 || string(f.Geom) == "null" {
+			t.Fatalf("feature %v was written with no geometry", f.ID)
+		}
+		if len(f.Props) == 0 || string(f.Props) == "null" {
+			t.Errorf("feature %v lost its properties — the tags are what classify a way", f.ID)
+		}
 	}
 }
 
@@ -331,4 +345,25 @@ func loadFixtureCfg(t *testing.T, raw string) (registry.Config, *Obj) {
 		t.Fatal(err)
 	}
 	return cfg, doc
+}
+
+type clippedFeature struct {
+	ID    any             `json:"id"`
+	Props json.RawMessage `json:"properties"`
+	Geom  json.RawMessage `json:"geometry"`
+}
+
+func featuresOf(t *testing.T, path string) []clippedFeature {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fc struct {
+		Features []clippedFeature `json:"features"`
+	}
+	if err := json.Unmarshal(raw, &fc); err != nil {
+		t.Fatal(err)
+	}
+	return fc.Features
 }


### PR DESCRIPTION
Metro-North and LIRR still failed on 0.4.8, now for a different reason. The
extract came from the right place this time — `northeast-corridor-region`, not
a Texas bus network — and the chart still said:

```
mta-metro-north: cut a rail extract to its window from
  build/northeast-corridor-region-rail.geojson (18882 ways)
mta-metro-north: build: exit status 1 — portolan: no regular-service rail ways
```

18882 ways, none of them rail. The file explains it:

```json
{"id":"way/800487225","type":"Feature",
 "properties":{"railway":"light_rail"},"geometry":null}
```

`clipFC` decoded into a struct that embedded `feature` — whose `Geom` field
carries `json:"geometry"` — beside a second field also tagged `"geometry"`.
Go resolves that conflict in favour of the shallower field, so the embedded
one was never populated, and every clipped feature went out with
`"geometry":null`. The right ways, with no shape.

## Changes

* `clipFC` decodes the geometry once, as the raw message that goes back out,
  and unmarshals a copy only to test the window.
* `feedPreflight` no longer fails a build when nothing covers the window. It
  logs and leaves the feed with the extract it has, which is what it did
  before this step existed — a partial railroad beats refusing to build. This
  hard-failed Amtrak and VIA on 0.4.9, whose windows are larger than any
  single extract in the registry.

## Test

`TestClipFCKeepsOnlyWhatMeetsTheWindow` now asserts the geometry *and* the
properties survive, not just the ids — asserting on ids alone is exactly what
let this reach production twice. The fixture carries `railway`/`usage` tags,
since those are what classify a way and an extract that keeps geometry while
dropping properties is equally useless.

Full suite green.